### PR TITLE
Accept RGBA images larger than 512 (git-cola.svg)

### DIFF
--- a/core/imgconverter.py
+++ b/core/imgconverter.py
@@ -42,7 +42,7 @@ MAX_HEIGHT = 5120
 # current max raster icon size in hicolor theme is 256 as of 2013/fedora-18
 # beyond that one probably shall use scalable icons
 # (SVG is currently unsupported)
-ICON_MAXSIZE = 512
+ICON_MAXSIZE = 1024
 
 # header consists of two decimal numbers, SPC and LF
 re_imghdr = re.compile(r'^\d+ \d+\n$')


### PR DESCRIPTION
When doing "/usr/lib/qubes/xdg-icon git-cola 512" (or any other max size, instead of 64) the result points to a .svg file of size 612x578.
After commenting line 8 of qubes.GetImageRGBA (see https://github.com/QubesOS/qubes-core-agent-linux/pull/12 ) to avoid forcing a max size, which creates wrong icons for most user-installed apps, i.e. Thunar, Meld, etc., we need to make this modification to avoid not creating icons for apps with large svg files with no smaller option, like git-cola and git-dag ("Failed to get icon for git-cola.desktop: Image size constraint violation: width=612 height=578 max_width=512 max_height=512) 
