### PR TITLE
Builds against linux v4.6-rc4

### DIFF
--- a/kernel-modules/u2mfn/u2mfn.c
+++ b/kernel-modules/u2mfn/u2mfn.c
@@ -76,7 +76,7 @@ static long u2mfn_ioctl(struct file *f, unsigned int cmd,
 	case U2MFN_GET_MFN_FOR_PAGE:
 		down_read(&current->mm->mmap_sem);
 		ret = get_user_pages
-		    (current, current->mm, data, 1, 1, 0, &user_page, 0);
+		    (data, 1, 1, 0, &user_page, 0);
 		up_read(&current->mm->mmap_sem);
 		if (ret != 1) {
 			printk("U2MFN_GET_MFN_FOR_PAGE: get_user_pages failed, ret=0x%lx\n", ret);


### PR DESCRIPTION
The helper macros for get_user*() APIs have been removed. This makes the u2mfn module fail to build. This PR fixes that.
See this commit https://github.com/torvalds/linux/commit/c12d2da56d0e07d230968ee2305aaa86b93a6832 for reference.
