### PR TITLE
Builds against 4.9

### DIFF
--- a/kernel-modules/u2mfn/u2mfn.c
+++ b/kernel-modules/u2mfn/u2mfn.c
@@ -75,7 +75,10 @@ static long u2mfn_ioctl(struct file *f, unsigned int cmd,
 	switch (cmd) {
 	case U2MFN_GET_MFN_FOR_PAGE:
 		down_read(&current->mm->mmap_sem);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+		ret = get_user_pages
+			(data, 1, (FOLL_WRITE | FOLL_FORCE), &user_page, 0);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
 		ret = get_user_pages
 		    (data, 1, 1, 0, &user_page, 0);
 #else


### PR DESCRIPTION
The function signature for get_user_pages() has changed in linux 4.9.

This is untested against linux versions < 4.9 but since it's such a minor change it should be okay.
