### PR TITLE
qubes-prepare-vm-kernel: Do not hardcode path to dracut

### DIFF
--- a/kernel-modules/qubes-prepare-vm-kernel
+++ b/kernel-modules/qubes-prepare-vm-kernel
@@ -51,7 +51,7 @@ function build_initramfs() {
     kver=$1
     output_file=$2
 
-    /sbin/dracut --nomdadmconf --nolvmconf --force \
+    dracut --nomdadmconf --nolvmconf --force \
         --modules "kernel-modules qubes-vm-simple" \
         --conf /dev/null --confdir /var/empty \
         -d "xenblk xen-blkfront cdrom ext4 jbd2 crc16 dm_snapshot" \


### PR DESCRIPTION
dracut has apparently moved from /sbin to /bin some time in the past.
Accommodate this change to avoid failures.

Signed-off-by: M. Vefa Bicakci <m.v.b@runbox.com>