### PR TITLE
Fall back to sync() if syncfs() is unavailable

### DIFF
--- a/qrexec-lib/unpack.c
+++ b/qrexec-lib/unpack.c
@@ -237,6 +237,8 @@ int do_unpack(void)
     cwd_fd = open(".", O_RDONLY);
     if (cwd_fd >= 0 && syncfs(cwd_fd) == 0 && close(cwd_fd) == 0)
         errno = saved_errno;
+#else
+    sync();
 #endif
 
     send_status_and_crc(errno, untrusted_namebuf);


### PR DESCRIPTION
(Do we still care about Debian wheezy? If not, please ignore this PR and revert c2c36d9c09f22d8e83b26fcd71182c267795111f instead.)