### PR TITLE
Fix off-by-one error in header length calculation

### DIFF
--- a/imgconverter/qubesimgconverter/__init__.py
+++ b/imgconverter/qubesimgconverter/__init__.py
@@ -49,9 +49,9 @@ ICON_MAXSIZE = 512
 
 # header consists of two decimal numbers, SPC and LF
 re_imghdr = re.compile(br'^\d+ \d+\n$')
-imghdrlen = lambda w, h: int(math.ceil(math.log10(w)) \
-    + math.ceil(math.log10(h)) \
-    + 2)
+def imghdrlen(w, h):
+    # width & height are inclusive max vals, and +2 for ' ' and '\n'
+    return len(str(w)) + len(str(h)) + 2
 
 class Image(object):
     def __init__(self, rgba, size):

--- a/imgconverter/qubesimgconverter/test.py
+++ b/imgconverter/qubesimgconverter/test.py
@@ -54,6 +54,7 @@ class TestCaseImage(unittest.TestCase):
 class TestCaseFunctionsAndConstants(unittest.TestCase):
     def test_00_imghdrlen(self):
         self.assertEqual(qubesimgconverter.imghdrlen(8, 15), len('8 15\n'))
+        self.assertEqual(qubesimgconverter.imghdrlen(100, 100), len('100 100\n'))
 
     def test_01_re_imghdr(self):
         self.assertTrue(qubesimgconverter.re_imghdr.match('8 15\n'))


### PR DESCRIPTION
int(ceil(log10(100))) is one lower than it should be when max widths are
powers of 10. This means providing a value of 100 when the max is 100
produces an unexpected failure.

Was never triggered because imghdrlen args are only hard-coded
constants, but a bug is a bug.