### PR TITLE
Fix gcc Werror because of a typo in a switch/case explicit fallthroug…

### DIFF
--- a/qrexec-lib/pack.c
+++ b/qrexec-lib/pack.c
@@ -100,7 +100,7 @@ void wait_for_result(void)
                      * desynchronized in this case */
                     return;
                 }
-                /* fall though */
+		/* fallthrough */
             default:
                 call_error_handler("File copy: %s%s%s",
                         strerror(hdr.error_code), last_filename_prefix, last_filename);


### PR DESCRIPTION
GCC crash because of -Werror=implicit-fallthrough. However the fallthrough exists but has a typo.

Thanks for omac777 analysis (https://github.com/QubesOS/qubes-builder/commit/7d0b8155a3ba5e09f09d71e4c7e9a60f85292deb)

However the fallthrough exists but has a typo