### PR TITLE
Fix python3 package names with respect to CentOS for consistency with python34 names

### DIFF
--- a/rpm_spec/qubes-utils.spec
+++ b/rpm_spec/qubes-utils.spec
@@ -15,7 +15,11 @@ URL:		http://www.qubes-os.org
 Requires:	udev
 Requires:	%{name}-libs
 Requires:	ImageMagick
+%if 0%{?rhel} >= 7
+Requires:	python34-qubesimgconverter
+%else
 Requires:	python3-qubesimgconverter
+%endif
 BuildRequires:  qubes-libvchan-devel
 BuildRequires:  python-setuptools
 %if 0%{?rhel} >= 7
@@ -39,18 +43,23 @@ Requires:   pycairo
 %description -n python2-qubesimgconverter
 Python package qubesimgconverter
 
+%if 0%{?rhel} >= 7
+%package -n python34-qubesimgconverter
+Summary:    Python package qubesimgconverter
+Requires:   python34
+Requires:   python34-cairo
+
+%description -n python34-qubesimgconverter
+Python package qubesimgconverter
+%else
 %package -n python3-qubesimgconverter
 Summary:    Python package qubesimgconverter
-%if 0%{?rhel} >= 7
-Requires:   python34
-Requires:   pycairo
-%else
 Requires:   python3
 Requires:   python3-cairo
-%endif
 
 %description -n python3-qubesimgconverter
 Python package qubesimgconverter
+%endif
 
 %package devel
 Summary:	Development headers for qubes-utils
@@ -115,7 +124,11 @@ rm -rf $RPM_BUILD_ROOT
 %{python_sitelib}/qubesimgconverter/test.py*
 %{python_sitelib}/qubesimgconverter-%{version}-py?.?.egg-info/*
 
+%if 0%{?rhel} >= 7
+%files -n python34-qubesimgconverter
+%else
 %files -n python3-qubesimgconverter
+%endif
 %{python3_sitelib}/qubesimgconverter/__init__.py
 %{python3_sitelib}/qubesimgconverter/imggen.py
 %{python3_sitelib}/qubesimgconverter/test.py


### PR DESCRIPTION
python34-cairo is on the road for EPEL but the package has to be built. I added a repo for that : qubes-python-cairo