### PR TITLE
Archlinux template fixes for QubesOS 4.0

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -31,7 +31,7 @@ md5sums=(SKIP)
 
 build() {
 
-for source in qrexec-lib udev qmemman core kernel-modules Makefile dracut; do
+for source in qrexec-lib udev qmemman core kernel-modules Makefile dracut imgconverter; do
   (ln -s $srcdir/../$source $srcdir/$source)
 done
 


### PR DESCRIPTION
Update the arch PKGBUILD script for QubesOS 4.0

Parent issue: QubesOS/qubes-issues#3185