### PR TITLE
Optimize and improve image tinting and loading/saving

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -45,7 +45,7 @@ make -C imgconverter all
 }
 
 package_qubes-vm-utils() {
-depends=(qubes-libvchan imagemagick python2-cairo)
+depends=(qubes-libvchan imagemagick python2-cairo python2-pillow python2-numpy python-pillow python-numpy)
 install=PKGBUILD-qubes-vm-utils.install
 
 # Install all for python2

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Vcs-Git: http://dsg.is/qubes/qubes-linux-utils.git
 
 Package: qubes-utils
 Architecture: any
-Depends: libvchan-xen, lsb-base, ${shlibs:Depends}, ${misc:Depends}
+Depends: libvchan-xen, lsb-base, python-pil, python-numpy, python3-pil, python3-numpy, ${shlibs:Depends}, ${misc:Depends}
 Conflicts: qubes-linux-utils
 Breaks: qubes-core-agent (<< 3.1.4)
 Recommends: python2.7

--- a/imgconverter/qubesimgconverter/__init__.py
+++ b/imgconverter/qubesimgconverter/__init__.py
@@ -35,7 +35,6 @@ import subprocess
 import sys
 import unittest
 
-import cairo
 
 # those are for "zOMG UlTRa HD! WalLLpapPer 8K!!1!" to work seamlessly;
 # 8192 * 5120 * 4 B = 160 MiB, so DoS by memory exhaustion is unlikely

--- a/imgconverter/qubesimgconverter/__init__.py
+++ b/imgconverter/qubesimgconverter/__init__.py
@@ -35,6 +35,7 @@ import subprocess
 import sys
 import unittest
 
+import PIL.Image
 
 # those are for "zOMG UlTRa HD! WalLLpapPer 8K!!1!" to work seamlessly;
 # 8192 * 5120 * 4 B = 160 MiB, so DoS by memory exhaustion is unlikely
@@ -71,6 +72,12 @@ get_from_stream(), get_from_vm(), get_xdg_icon_from_vm(), get_through_dvm()'''
 
         if p.wait():
             raise Exception('Conversion failed')
+
+    def save_pil(self, dst):
+        '''Save image to disk using PIL.'''
+
+        img = PIL.Image.frombytes('RGBA', self._size, self._rgba)
+        img.save(dst)
 
     @property
     def data(self):
@@ -128,6 +135,12 @@ get_from_stream(), get_from_vm(), get_xdg_icon_from_vm(), get_through_dvm()'''
         p.wait()
 
         return cls(rgba=rgba, size=size)
+
+    def load_from_file_pil(cls, filename):
+        '''Loads image from local file using PIL.'''
+        img = PIL.Image.open(filename)
+        img = img.convert('RGBA')
+        return cls(rgba=img.tobytes(), size=img.size)
 
     @classmethod
     def get_from_stream(cls, stream, max_width=MAX_WIDTH, max_height=MAX_HEIGHT):
@@ -239,9 +252,9 @@ def hex_to_float(colour, channels=3, depth=8):
 def tint(src, dst, colour):
     '''Tint image to reflect vm label.
 
-    src and dst may specify format, like png:aqq.gif'''
+    src and dst may NOT specify ImageMagick format'''
 
-    Image.load_from_file(src).tint(colour).save(dst)
+    Image.load_from_file_pil(src).tint(colour).save_pil(dst)
 
 
 # vim: ft=python sw=4 ts=4 et

--- a/rpm_spec/qubes-utils.spec
+++ b/rpm_spec/qubes-utils.spec
@@ -35,6 +35,8 @@ Common Linux files for Qubes Dom0 and VM
 Summary:    Python package qubesimgconverter
 Requires:   python
 Requires:   pycairo
+Requires:   python2-pillow
+Requires:   python2-numpy
 
 %description -n python2-qubesimgconverter
 Python package qubesimgconverter
@@ -48,6 +50,8 @@ Requires:   pycairo
 Requires:   python3
 Requires:   python3-cairo
 %endif
+Requires:   python3-pillow
+Requires:   python3-numpy
 
 %description -n python3-qubesimgconverter
 Python package qubesimgconverter


### PR DESCRIPTION
The current image tinting code is horrendously slow mostly because it processes single pixels in pure Python doing lots of math, making VM creation take 10+ seconds just to tint the images.

This commit series:
1. Adds PIL and numpy dependencies (note: this is UNTESTED, at least some of the distributions could be wrong)
2. Uses Python PIL instead of ImageMagick to load and save images when tinting, avoiding having to spawn processes
3. Reimplements the tinting algorithm using numpy with optimized math and only using integer operations, with division only at the end
4. Replaces the tinting algorithm with a new one that also partially preserves image saturation, but ensures a minimum chroma so that even greyscale images will look tinted

The last commit can be removed if the original tinting algorithm (that ignores image saturation) is preferred.

Currently the PIL load/save code is only used when tinting, since other users may need ImageMagick format specifications or potentially different format support. Perhaps some additional work could allow to completely remove the ImageMagick code.
