### PR TITLE
This PR specifies the integer width explicitly

### DIFF
--- a/qrexec-lib/libqubes-rpc-filecopy.h
+++ b/qrexec-lib/libqubes-rpc-filecopy.h
@@ -35,13 +35,13 @@
 #include <sys/types.h>
 
 struct file_header {
-    unsigned int namelen;
-    unsigned int mode;
-    unsigned long long filelen;
-    unsigned int atime;
-    unsigned int atime_nsec;
-    unsigned int mtime;
-    unsigned int mtime_nsec;
+    uint32_t namelen;
+    uint32_t mode;
+    uint64_t filelen;
+    uint32_t atime;
+    uint32_t atime_nsec;
+    uint32_t mtime;
+    uint32_t mtime_nsec;
 };
 
 struct result_header {


### PR DESCRIPTION
This PR specifies the integer width explicitly to match `result_header_ext` etc.

also, can someone explain to me why `send_status_and_crc` does not need
to set `_pad` to prevent leaking stack memory in the responses?