### PR TITLE
Fix headers

### DIFF
--- a/qrexec-lib/txrx-vchan.c
+++ b/qrexec-lib/txrx-vchan.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <errno.h>
+#include <sys/select.h>
 #include <libvchan.h>
 
 int wait_for_vchan_or_argfd_once(libvchan_t *ctrl, int max, fd_set * rdset, fd_set * wrset)

--- a/qrexec-lib/unix-server.c
+++ b/qrexec-lib/unix-server.c
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 //#include "qrexec.h"
 
 int get_server_socket(const char *socket_address)


### PR DESCRIPTION
memset() and strncpy() needs string.h, while fd_set is actually defined in sys/socket.h

This problem arise when one tries to compile qrexec-lib on a different libc than the one used in the build (assuming glibc).