### PR TITLE
udev: create /dev/mapper/dmroot -> xvda3 symlink when its mounted directly

### DIFF
--- a/rpm_spec/qubes-utils.spec.in
+++ b/rpm_spec/qubes-utils.spec.in
@@ -118,7 +118,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
-/lib/udev/rules.d/99-qubes-*.rules
+/lib/udev/rules.d/*-qubes-*.rules
 /usr/lib/qubes/udev-*
 %{_sbindir}/meminfo-writer
 %{_unitdir}/qubes-meminfo-writer.service

--- a/udev/Makefile
+++ b/udev/Makefile
@@ -5,6 +5,7 @@ install:
 	cp udev-qubes-block.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-block.rules
 	cp udev-qubes-usb.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-usb.rules
 	cp udev-qubes-misc.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-misc.rules
+	cp udev-qubes-dmroot.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/90-qubes-dmroot.rules
 
 	mkdir -p $(DESTDIR)$(SCRIPTSDIR)
 	cp udev-block-add-change $(DESTDIR)$(SCRIPTSDIR)

--- a/udev/udev-qubes-dmroot.rules
+++ b/udev/udev-qubes-dmroot.rules
@@ -1,0 +1,5 @@
+# Create /dev/mapper/dmroot symlink on TemplateVM/StandaloneVM to make
+# grub-mkconfig happy.
+# On TemplateBasedVM, it is really a device mapper device.
+
+SUBSYSTEM=="block", ENV{ID_PART_ENTRY_NAME}=="Root\x20filesystem", ATTR{ro}=="0", SYMLINK+="mapper/dmroot"


### PR DESCRIPTION
When root device is available read-write (TemplateVM/StandaloneVM), its
mounted directly, instead of using device-mapper layer. But
/dev/mapper/dmroot still needs to exists (it is pointed from
/etc/fstab), otherwise various tools, including grub-mkconfig get
confused.
Create a symlink using udev rule. It is already done in initramfs, and
in case of Fedora that udev rule/symlink survive switching to
non-initramfs udev, but not on Debian. So, add appropriate udev rules
file.

Fixes QubesOS/qubes-issues#3178