### PR TITLE
Order qubes-meminfo-writer-dom0 before systemd-user-sessions

### DIFF
--- a/qmemman/qubes-meminfo-writer-dom0.service
+++ b/qmemman/qubes-meminfo-writer-dom0.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Qubes memory information reporter
+Before=systemd-user-sessions.service
 After=qubes-core.service qubes-qmemman.service
 ConditionPathExists=/var/run/qubes/qmemman.sock
 


### PR DESCRIPTION
`qubes-vm@.service` would already [cause this ordering](https://github.com/QubesOS/qubes-core-admin/blob/e1378f70fbf8d686f744a679f44bd1f08a0100d2/linux/systemd/qubes-vm%40.service#L3-L4), but not every user has any `autostart=True` VMs.

Also needed to maybe f*x QubesOS/qubes-issues#3149 at some point.