### PR TITLE
qrexec-lib/unpack: option to wait for free disk space

### DIFF
--- a/debian/libqubes-rpc-filecopy2.shlibs
+++ b/debian/libqubes-rpc-filecopy2.shlibs
@@ -1,1 +1,1 @@
-libqubes-rpc-filecopy 2 libqubes-rpc-filecopy2 (>= 3.1.3)
+libqubes-rpc-filecopy 2 libqubes-rpc-filecopy2 (>= 4.1.7)

--- a/qrexec-lib/libqubes-rpc-filecopy.h
+++ b/qrexec-lib/libqubes-rpc-filecopy.h
@@ -74,6 +74,11 @@ int copy_file(int outfd, int infd, long long size, unsigned long *crc32);
 const char *copy_file_status_to_str(int status);
 void set_size_limit(unsigned long long new_bytes_limit, unsigned long long new_files_limit);
 void set_verbose(int value);
+/*
+ * Delay extracting a file if there is no enough space for it - wait for space
+ * for this file, plus a given margin.
+ */
+void set_wait_for_space(unsigned long margin);
 /* register open fd to /proc/PID/fd of this process */
 void set_procfs_fd(int value);
 int write_all(int fd, const void *buf, int size);


### PR DESCRIPTION
Add an option to wait for disk space before extracting a file from qfile
archive. This will allow extracting backup archive using much smaller
temporary space (only enough to hold few chunks, not the whole archive).

Technically, libqubes-rpc-filecopy library got a set_wait_for_space()
function, accepting a margin (in bytes) to be kept free.

QubesOS/qubes-issues#4791
QubesOS/qubes-issues#5310
