### PR TITLE
partition full volatile for non-COW setups too

### DIFF
--- a/dracut/full-dmroot/qubes_cow_setup.sh
+++ b/dracut/full-dmroot/qubes_cow_setup.sh
@@ -79,8 +79,8 @@ if [ `cat /sys/class/block/$ROOT_DEV/ro` = 1 ] ; then
         die "volatile.img smaller than 1GB, cannot continue"
     fi
     sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-1,$SWAP_SIZE,S
-,,L
+xvdc1: type=82,start=2048,size=$SWAP_SIZE
+xvdc2: type=83
 EOF
     if [ $? -ne 0 ]; then
         die "Qubes: failed to setup partitions on volatile device"
@@ -97,7 +97,8 @@ else
     log_begin "Qubes: Doing R/W setup for TemplateVM..."
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
     sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-1,$SWAP_SIZE,S
+xvdc1: type=82,start=2048,size=$SWAP_SIZE
+xvdc3: type=83
 EOF
     if [ $? -ne 0 ]; then
         die "Qubes: failed to setup partitions on volatile device"

--- a/dracut/simple/init.sh
+++ b/dracut/simple/init.sh
@@ -53,8 +53,8 @@ if [ `cat /sys/class/block/$ROOT_DEV/ro` = 1 ] ; then
         die "volatile.img smaller than 1GB, cannot continue"
     fi
     /sbin/sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-2048,$SWAP_SIZE,S
-,,L
+xvdc1: type=82,start=2048,size=$SWAP_SIZE
+xvdc2: type=83
 EOF
     if [ $? -ne 0 ]; then
         echo "Qubes: failed to setup partitions on volatile device"
@@ -72,7 +72,8 @@ else
     echo "Qubes: Doing R/W setup for TemplateVM..."
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
     /sbin/sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-2048,$SWAP_SIZE,S
+xvdc1: type=82,start=2048,size=$SWAP_SIZE
+xvdc3: type=83
 EOF
     if [ $? -ne 0 ]; then
         die "Qubes: failed to setup partitions on volatile device"


### PR DESCRIPTION
this adds a xvdc3 partition for the "unused" 9GB of volatile volume on non-cow setups.
having the space already partitioned makes it easier to use these 9GB as additional swap or temp space (since you dont have to swapoff and repartition and hope no auto-rescan gets in the way).

sfdisk "named" style is required to skip over slot 2, the spec for COW setup is changed to match.
slot 3 is used to avoid confusion with slot 2 (for cow usage).
even though it is created as type linux it can be used for swap too, just mkswap+swapon.
the "start=2048" doesnt seem to be required in the fedora 29+30 version of sfdisk but is kept "just in case" there are other sfdisk variants out there with different defaults. 

tested and working with a 5.2.16 build on fedora for non-cow.
please pick to release branches as needed. (or should i make separate PRs for that?)