### PR TITLE
debian: fix dependencies of qubes-kernel-vm-support pkg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,8 +24,11 @@ Description: Qubes Linux utilities
 
 Package: qubes-kernel-vm-support
 Architecture: any
-Recommends: initramfs-tools
-Depends: ${misc:Depends}
+Depends:
+ busybox,
+ initramfs-tools | dracut,
+ grub2-common,
+ ${misc:Depends}
 Description: Qubes VM kernel and initramfs modules
  This package contains:
  1. mkinitramfs module required to setup Qubes VM root filesystem. This package


### PR DESCRIPTION
Add missing busybox (required for grep inside initramfs).
Add missing grub2-common (required for grub config generation).
Convert Recommends: initramfs-tools to Depends: initramfs-tools |
dracut (see also QubesOS/qubes-issues#3361).

Fixes QubesOS/qubes-issues#5490