### PR TITLE
Image.get_from_stream_async(): fix large sizes

### DIFF
--- a/imgconverter/qubesimgconverter/__init__.py
+++ b/imgconverter/qubesimgconverter/__init__.py
@@ -256,7 +256,7 @@ get_from_stream(), get_from_vm(), get_xdg_icon_from_vm(), get_through_dvm()'''
         del untrusted_width, untrusted_height
 
         expected_data_len = width * height * 4    # RGBA
-        untrusted_data = await reader.read(expected_data_len)
+        untrusted_data = await reader.readexactly(expected_data_len)
         if len(untrusted_data) != expected_data_len:
             raise ValueError( \
                 'Image data length violation (is {0}, should be {1})'.format( \

--- a/imgconverter/qubesimgconverter/test.py
+++ b/imgconverter/qubesimgconverter/test.py
@@ -70,8 +70,9 @@ class TestCaseImage(asynctest.TestCase):
         reader = asyncio.StreamReader()
         reader.feed_data('{0[0]} {0[1]}\n'.format(self.size).encode() +
                          self.rgba[:-1])  # one byte too short
+        reader.feed_eof()
 
-        with self.assertRaisesRegexp(ValueError, 'data length violation'):
+        with self.assertRaises(asyncio.streams.IncompleteReadError):
             image = await qubesimgconverter.Image.get_from_stream_async(reader)
 
     async def test_22_get_from_stream_too_big(self):


### PR DESCRIPTION
StreamReader.read() returns as soon as some data is received. This
fails when receiving large icons that do not all fit in the buffer.