### PR TITLE
imgconverter: make output reproducible by omitting timestamps

### DIFF
--- a/imgconverter/qubesimgconverter/__init__.py
+++ b/imgconverter/qubesimgconverter/__init__.py
@@ -64,7 +64,10 @@ get_from_stream(), get_from_vm(), get_xdg_icon_from_vm(), get_through_dvm()'''
         p = subprocess.Popen(['convert',
             '-depth', '8',
             '-size', '{0[0]}x{0[1]}'.format(self._size),
-            'rgba:-', dst], stdin=subprocess.PIPE)
+            'rgba:-',
+            '+set', 'date:create',
+            '+set', 'date:modify',
+            dst], stdin=subprocess.PIPE)
         p.stdin.write(self._rgba)
         p.stdin.close()
 


### PR DESCRIPTION
Don't embed creation and last-modified dates inside some output file
formats like PNG.

Such an output file now becomes a fixed point of qvm-convert-image,
making it verifiably nonmalicious and thus ideal to e.g. check into a
git repository.