### PR TITLE
dracut: enable swap as early as possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ else
 LIBDIR ?= /usr/lib
 endif
 SCRIPTSDIR ?= /usr/lib/qubes
-SYSLIBDIR ?= /lib
+SYSLIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include
 
 export LIBDIR SCRIPTSDIR SYSLIBDIR INCLUDEDIR

--- a/debian/qubes-utils.install
+++ b/debian/qubes-utils.install
@@ -1,5 +1,5 @@
 usr/sbin/meminfo-writer
 lib/systemd/system/qubes-meminfo-writer.service
 usr/lib/qubes/*
-lib/udev/*
+usr/lib/udev/*
 usr/lib/tmpfiles.d/xen-devices-qubes.conf

--- a/debian/qubes-utils.install
+++ b/debian/qubes-utils.install
@@ -2,3 +2,4 @@ usr/sbin/meminfo-writer
 lib/systemd/system/qubes-meminfo-writer.service
 usr/lib/qubes/*
 lib/udev/*
+usr/lib/tmpfiles.d/xen-devices-qubes.conf

--- a/dracut/full-dmroot/module-setup.sh
+++ b/dracut/full-dmroot/module-setup.sh
@@ -17,5 +17,6 @@ install() {
     inst_hook pre-trigger 90 $moddir/qubes_cow_setup.sh
     inst_multiple \
         sfdisk \
+        swapon \
         mkswap
 }

--- a/dracut/full-dmroot/qubes_cow_setup.sh
+++ b/dracut/full-dmroot/qubes_cow_setup.sh
@@ -88,6 +88,9 @@ EOF
     fi
     while ! [ -e /dev/xvdc1 ]; do sleep 0.1; done
     mkswap /dev/xvdc1
+    # enable swap right now, because systemd may want to run fsck in initramfs
+    # already and it require some more memory
+    swapon /dev/xvdc1
     while ! [ -e /dev/xvdc2 ]; do sleep 0.1; done
 
     echo "0 `cat /sys/class/block/$ROOT_DEV/size` snapshot /dev/$ROOT_DEV /dev/xvdc2 N 16" | \
@@ -106,6 +109,9 @@ EOF
     fi
     while ! [ -e /dev/xvdc1 ]; do sleep 0.1; done
     mkswap /dev/xvdc1
+    # enable swap right now, because systemd may want to run fsck in initramfs
+    # already and it require some more memory
+    swapon /dev/xvdc1
     mkdir -p /etc/udev/rules.d
     printf 'KERNEL=="%s", SYMLINK+="mapper/dmroot"\n' "$ROOT_DEV" >> \
         /etc/udev/rules.d/99-root.rules

--- a/rpm_spec/qubes-utils.spec.in
+++ b/rpm_spec/qubes-utils.spec.in
@@ -79,7 +79,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
-/lib/udev/rules.d/*-qubes-*.rules
+/usr/lib/udev/rules.d/*-qubes-*.rules
 /usr/lib/tmpfiles.d/xen-devices-qubes.conf
 /usr/lib/qubes/udev-*
 %{_sbindir}/meminfo-writer

--- a/rpm_spec/qubes-utils.spec.in
+++ b/rpm_spec/qubes-utils.spec.in
@@ -80,6 +80,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root,-)
 /lib/udev/rules.d/*-qubes-*.rules
+/usr/lib/tmpfiles.d/xen-devices-qubes.conf
 /usr/lib/qubes/udev-*
 %{_sbindir}/meminfo-writer
 %{_unitdir}/qubes-meminfo-writer.service

--- a/udev/Makefile
+++ b/udev/Makefile
@@ -6,6 +6,8 @@ install:
 	cp udev-qubes-usb.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-usb.rules
 	cp udev-qubes-misc.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-misc.rules
 	cp udev-qubes-dmroot.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/90-qubes-dmroot.rules
+	mkdir -p $(DESTDIR)$(SYSLIBDIR)/tmpfiles.d
+	cp xen-devices-qubes.conf $(DESTDIR)$(SYSLIBDIR)/tmpfiles.d/xen-devices-qubes.conf
 
 	mkdir -p $(DESTDIR)$(SCRIPTSDIR)
 	cp udev-block-add-change $(DESTDIR)$(SCRIPTSDIR)

--- a/udev/xen-devices-qubes.conf
+++ b/udev/xen-devices-qubes.conf
@@ -1,0 +1,7 @@
+# Adjust xen devices permissions early
+z /dev/xen/evtchn    0660 - qubes -
+z /dev/xen/gntdev    0660 - qubes -
+z /dev/xen/gntalloc  0660 - qubes -
+z /dev/xen/privcmd   0660 - qubes -
+z /dev/xen/xenbus    0660 - qubes -
+z /dev/xen/hypercall 0660 - qubes -


### PR DESCRIPTION
Enable swap just after creating the partition. This ensures early
startup services (including fsck which in recent Fedora versions is
called inside initramfs already) will not run out of memory.

Do this only for the in-VM kernel case (initramfs built by the VM
itself). Avoid this change in "simple" dracut module (for dom0-provided
kernel), as it may result in surprising effects in the VM that didn't
expected it at this stage (for example when it calls mkswap itself).

Fixes QubesOS/qubes-issues#6174