### PR TITLE
Mass replace: ‘/var/run’ → ‘/run’

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -13,7 +13,7 @@ arch=("x86_64")
 url="http://qubes-os.org/"
 license=('GPL')
 groups=()
-makedepends=(gcc make pkgconfig 'python-setuptools')
+makedepends=(gcc make pkgconfig 'python-setuptools' qubes-libvchan-xen)
 checkdepends=()
 optdepends=()
 provides=()
@@ -32,7 +32,7 @@ md5sums=(SKIP)
 build() {
 
 for source in qrexec-lib udev qmemman core kernel-modules Makefile dracut imgconverter; do
-  (ln -s $srcdir/../$source $srcdir/$source)
+  (ln -s -- "$srcdir/../$source" "$srcdir/$source")
 done
 
 make all
@@ -43,7 +43,7 @@ package_qubes-vm-utils() {
 depends=(imagemagick python-cairo python-pillow python-numpy)
 install=PKGBUILD-qubes-vm-utils.install
 
-make install DESTDIR=$pkgdir LIBDIR=/usr/lib SYSLIBDIR=/usr/lib SBINDIR=/usr/bin
+make install "DESTDIR=$pkgdir" LIBDIR=/usr/lib SYSLIBDIR=/usr/lib SBINDIR=/usr/bin
 }
 
 package_qubes-vm-kernel-support() {

--- a/udev/udev-block-add-change
+++ b/udev/udev-block-add-change
@@ -83,7 +83,7 @@ done
 
 # cache slave devices for remove event
 if [ -n "$DM_NAME" ]; then
-    ls -1 /sys$DEVPATH/slaves/ > /var/run/qubes/block-slave-cache-$NAME
+    ls -1 /sys$DEVPATH/slaves/ > /run/qubes/block-slave-cache-$NAME
 fi
 
 # then take care of this device:

--- a/udev/udev-block-remove
+++ b/udev/udev-block-remove
@@ -7,10 +7,10 @@ QDB_KEY="/qubes-block-devices/$NAME"
 qubesdb-rm "$QDB_KEY/"
 qubesdb-write /qubes-block-devices ''
 
-if [ -r /var/run/qubes/block-slave-cache-$NAME ]; then
+if [ -r /run/qubes/block-slave-cache-$NAME ]; then
     # update info about underlying devices of device-mapper (if any);
-    for dev in $(cat /var/run/qubes/block-slave-cache-$NAME); do
+    for dev in $(cat /run/qubes/block-slave-cache-$NAME); do
         udevadm trigger /sys/class/block/$dev
     done
-    rm -f /var/run/qubes/block-slave-cache-$NAME
+    rm -f /run/qubes/block-slave-cache-$NAME
 fi


### PR DESCRIPTION
The former is deprecated in systemd.

Part of QubesOS/qubes-issues#6315.