### PR TITLE
Makefile: remove broken 32-bit host check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-ifeq ($(shell uname -m),x86_64)
 LIBDIR ?= /usr/lib64
-else
-LIBDIR ?= /usr/lib
-endif
 SCRIPTSDIR ?= /usr/lib/qubes
 SYSLIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include


### PR DESCRIPTION
Don't check `uname -m == x86_64` to determine whether to use
/usr/lib64 or /usr/lib and just use /usr/lib64 unconditionally.

This fixes the build on other 64-bit hosts, like ppc64le, at the
cost of removing the 32-bit fallback path which didn't work anyways
since the rpm specs unconditionally assume lib64.