### PR TITLE
stable-id:  introduce qname variable to address block and usb devices

### DIFF
--- a/udev/udev-block-add-change
+++ b/udev/udev-block-add-change
@@ -8,7 +8,7 @@ NAME=${DEVNAME#/dev/}
 DESC="`echo "${ID_MODEL} (${ID_FS_LABEL})" | iconv -f utf8 -t ascii//TRANSLIT`"
 SIZE=$[ $(cat /sys/$DEVPATH/size) * 512 ]
 MODE=w
-QDB_KEY="/qubes-block-devices/$NAME"
+QDB_KEY="/qubes-block-devices/$QNAME"
 
 xs_remove() {
     if is_attached /sys$DEVPATH; then

--- a/udev/udev-block-remove
+++ b/udev/udev-block-remove
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 NAME=${DEVNAME#/dev/}
-QDB_KEY="/qubes-block-devices/$NAME"
+QDB_KEY="/qubes-block-devices/$QNAME"
 # Trailing slash is intentional - it will remove the whole directory, instead of
 # a single base entry
 qubesdb-rm "$QDB_KEY/"

--- a/udev/udev-qubes-block.rules
+++ b/udev/udev-qubes-block.rules
@@ -22,7 +22,7 @@ KERNEL=="dm-*", ENV{DM_NAME}=="", GOTO="qubes_block_end"
 ACTION=="add", ENV{ID_SERIAL}=="?*", PROGRAM="/bin/sh -c '/usr/bin/uuidgen -s -n @oid -N $env{ID_SERIAL}$env{PARTN}|cut -d- -f5'", ENV{QNAME}="$result"
 
 # check if device already exist in qubesdb
-ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/usr/bin/qubesdb-read -q /qubes-block-devices/$env{QNAME}/desc", RESULT!="?*", GOTO="skip_qname_fallback"
+ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/bin/sh -c '/usr/bin/qubesdb-read -q /qubes-block-devices/$env{QNAME}/desc || echo 1'", RESULT=="1", GOTO="skip_qname_fallback"
 
 # fallback for duplicates
 ACTION=="add", PROGRAM="/usr/bin/basename $env{DEVNAME}", ENV{QNAME}="$result"

--- a/udev/udev-qubes-block.rules
+++ b/udev/udev-qubes-block.rules
@@ -19,7 +19,7 @@ KERNEL=="dm-*", ENV{DM_NAME}=="origin-*", GOTO="qubes_block_end"
 KERNEL=="dm-*", ENV{DM_NAME}=="", GOTO="qubes_block_end"
 
 # generate cropped uuid and populate qname variable
-ACTION=="add", ENV{ID_SERIAL}=="?*", PROGRAM="/bin/sh -c '/usr/bin/uuidgen -s -n @oid -N $env{ID_SERIAL}$env{PARTN}|cut -d- -f5'", ENV{QNAME}="$result"
+ACTION=="add", ENV{ID_SERIAL}=="?*", PROGRAM="/usr/bin/uuidgen -s -n @oid -N $env{ID_SERIAL}$env{PARTN}", ENV{QNAME}="$result"
 
 # check if device already exist in qubesdb
 ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/bin/sh -c '/usr/bin/qubesdb-read -q /qubes-block-devices/$env{QNAME}/desc || echo 1'", RESULT=="1", GOTO="skip_qname_fallback"
@@ -28,6 +28,8 @@ ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/bin/sh -c '/usr/bin/qubesdb-read -q /
 ACTION=="add", PROGRAM="/usr/bin/basename $env{DEVNAME}", ENV{QNAME}="$result"
 
 LABEL="skip_qname_fallback"
+
+ACTION=="add", SYMLINK+="$env{QNAME}"
 
 IMPORT{db}="QNAME"
 

--- a/udev/udev-qubes-block.rules
+++ b/udev/udev-qubes-block.rules
@@ -18,6 +18,19 @@ KERNEL=="dm-*", ENV{DM_NAME}=="snapshot-*", GOTO="qubes_block_end"
 KERNEL=="dm-*", ENV{DM_NAME}=="origin-*", GOTO="qubes_block_end"
 KERNEL=="dm-*", ENV{DM_NAME}=="", GOTO="qubes_block_end"
 
+# generate cropped uuid and populate qname variable
+ACTION=="add", ENV{ID_SERIAL}=="?*", PROGRAM="/bin/sh -c '/usr/bin/uuidgen -s -n @oid -N $env{ID_SERIAL}$env{PARTN}|cut -d- -f5'", ENV{QNAME}="$result"
+
+# check if device already exist in qubesdb
+ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/usr/bin/qubesdb-read -q /qubes-block-devices/$env{QNAME}/desc", RESULT!="?*", GOTO="skip_qname_fallback"
+
+# fallback for duplicates
+ACTION=="add", PROGRAM="/usr/bin/basename $env{DEVNAME}", ENV{QNAME}="$result"
+
+LABEL="skip_qname_fallback"
+
+IMPORT{db}="QNAME"
+
 ACTION=="add", RUN+="/usr/lib/qubes/udev-block-add-change"
 ACTION=="change", RUN+="/usr/lib/qubes/udev-block-add-change"
 ACTION=="remove", RUN+="/usr/lib/qubes/udev-block-remove"

--- a/udev/udev-qubes-usb.rules
+++ b/udev/udev-qubes-usb.rules
@@ -10,7 +10,7 @@ ENV{ID_VENDOR}=="QEMU", GOTO="qubes_usb_end"
 ACTION=="add", ENV{ID_VENDOR_ID}=="?*", ENV{ID_MODEL_ID}=="?*", ENV{QNAME}="0x$env{ID_VENDOR_ID}_0x$env{ID_MODEL_ID}"
 
 # check if device already exist in qubesdb
-ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/usr/bin/qubesdb-read -q /qubes-usb-devices/$env{QNAME}/desc", RESULT!="?*", GOTO="skip_qname_fallback"
+ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/bin/sh -c '/usr/bin/qubesdb-read -q /qubes-usb-devices/$env{QNAME}/desc || echo 1'", RESULT=="1", GOTO="skip_qname_fallback"
 
 # fallback for device duplicates
 ACTION=="add", PROGRAM="sh -c 'basename $env{DEVPATH} | tr . _'", ENV{QNAME}="$result"

--- a/udev/udev-qubes-usb.rules
+++ b/udev/udev-qubes-usb.rules
@@ -6,6 +6,19 @@ SUBSYSTEM!="usb", GOTO="qubes_usb_end"
 # ignore qemu emulated devices in HVM
 ENV{ID_VENDOR}=="QEMU", GOTO="qubes_usb_end"
 
+# use vendor and model ids to set qname variable
+ACTION=="add", ENV{ID_VENDOR_ID}=="?*", ENV{ID_MODEL_ID}=="?*", ENV{QNAME}="0x$env{ID_VENDOR_ID}_0x$env{ID_MODEL_ID}"
+
+# check if device already exist in qubesdb
+ACTION=="add", ENV{QNAME}=="?*", PROGRAM="/usr/bin/qubesdb-read -q /qubes-usb-devices/$env{QNAME}/desc", RESULT!="?*", GOTO="skip_qname_fallback"
+
+# fallback for device duplicates
+ACTION=="add", PROGRAM="sh -c 'basename $env{DEVPATH} | tr . _'", ENV{QNAME}="$result"
+
+LABEL="skip_qname_fallback"
+
+IMPORT{db}="QNAME"
+
 ACTION=="add", IMPORT{program}="/usr/lib/qubes/udev-usb-add-change"
 ACTION=="change", IMPORT{program}="/usr/lib/qubes/udev-usb-add-change"
 ACTION=="remove", RUN+="/usr/lib/qubes/udev-usb-remove"

--- a/udev/udev-usb-add-change
+++ b/udev/udev-usb-add-change
@@ -12,9 +12,6 @@
 [ "`echo $TYPE | cut -f1 -d/`" = "9" ] && exit 0
 [ "$DEVTYPE" != "usb_device" ] && exit 0
 
-# qubesdb doesn't allow dot in key name
-XSNAME=`basename ${DEVPATH} | tr . _`
-
 # FIXME: For some devices (my Cherry keyboard) ID_SERIAL does not
 # contain proper human-readable name, should find better method to
 # build devide description.
@@ -29,7 +26,7 @@ if echo $DEVPATH | grep -q /vhci_hcd; then
     exit 0
 fi
 
-QDB_KEY="/qubes-usb-devices/$XSNAME"
+QDB_KEY="/qubes-usb-devices/$QNAME"
 
 qubesdb-write "$QDB_KEY/desc" "$DESC"
 qubesdb-write "$QDB_KEY/usb-ver" "$VERSION"

--- a/udev/udev-usb-remove
+++ b/udev/udev-usb-remove
@@ -3,8 +3,7 @@
 # FIXME: Ignore USB hubs.
 [ "`echo $TYPE | cut -f1 -d/`" = "9" ] && exit 0
 
-NAME=`basename ${DEVPATH} | tr . _`
-QDB_KEY="/qubes-usb-devices/$NAME/"
+QDB_KEY="/qubes-usb-devices/$QNAME/"
 
 qubesdb-rm "$QDB_KEY"
 qubesdb-write /qubes-usb-devices ''


### PR DESCRIPTION
QubesOS/qubes-issues/issues/2272

Rework of udev rules that allows to address block and usb devices by their attributes. 

This solution can be extended to support existing block UUIDs, but it requires increased qubesdb path limit.