### PR TITLE
Force exporting of loop devices

### DIFF
--- a/udev/udev-block-add-change
+++ b/udev/udev-block-add-change
@@ -90,7 +90,7 @@ fi
 
 # udev rules already excluded this device:
 
-if [ "$DM_UDEV_DISABLE_DISK_RULES_FLAG" = "1" ]; then
+if [ -z "$QUBES_EXPORT_BLOCK_DEVICE" ] && [ "$DM_UDEV_DISABLE_DISK_RULES_FLAG" = "1" ]; then
     xs_remove
     exit 0
 fi

--- a/udev/udev-qubes-block.rules
+++ b/udev/udev-qubes-block.rules
@@ -11,7 +11,7 @@ KERNEL=="xvda|xvdb|xvdc*|xvdd", ENV{UDISKS_IGNORE}="1"
 ENV{MAJOR}=="202", GOTO="qubes_block_end"
 
 # skip devices excluded elsewhere
-ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}=="1", GOTO="qubes_block_end"
+ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}=="1", ENV{QUBES_EXPORT_BLOCK_DEVICE}!="1", GOTO="qubes_block_end"
 
 # Skip device-mapper devices
 KERNEL=="dm-*", ENV{DM_NAME}=="snapshot-*", GOTO="qubes_block_end"
@@ -23,3 +23,5 @@ ACTION=="change", RUN+="/usr/lib/qubes/udev-block-add-change"
 ACTION=="remove", RUN+="/usr/lib/qubes/udev-block-remove"
 
 LABEL="qubes_block_end"
+
+# vim: set ft=udevrules ff=unix fenc=UTF-8 eol:


### PR DESCRIPTION
core-admin-linux will set QUBES_EXPORT_BLOCK_DEVICES to 1 for them,
unless they are part of a file pool.  See https://github.com/QubesOS/qubes-core-admin-linux/pull/71.