### PR TITLE
spec: allow matching python3.10 in %files

### DIFF
--- a/rpm_spec/qubes-utils.spec.in
+++ b/rpm_spec/qubes-utils.spec.in
@@ -91,7 +91,7 @@ rm -rf $RPM_BUILD_ROOT
 %{python3_sitelib}/qubesimgconverter/imggen.py
 %{python3_sitelib}/qubesimgconverter/test.py
 %{python3_sitelib}/qubesimgconverter/test_integ.py
-%{python3_sitelib}/qubesimgconverter-%{version}-py?.?.egg-info
+%{python3_sitelib}/qubesimgconverter-%{version}-py?.[0-9]*.egg-info
 %{python3_sitelib}/qubesimgconverter/__pycache__
 
 %files libs


### PR DESCRIPTION
QubesOS/qubes-issues#6969