### PR TITLE
SELinux policy for meminfo-writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ deb/
 *.py[co]
 pkgs
 debian/changelog.*
+/selinux/tmp/
+/selinux/*.pp

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,24 @@ SYSLIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include
 
 export LIBDIR SCRIPTSDIR SYSLIBDIR INCLUDEDIR
+.PHONY: all selinux install install-selinux install-fedora-kernel-support install-debian-kernel-support clean
 
 all:
 	$(MAKE) -C qrexec-lib all
 	$(MAKE) -C qmemman all
 	$(MAKE) -C imgconverter all
+selinux:
+	$(MAKE) -f /usr/share/selinux/devel/Makefile -C selinux qubes-meminfo-writer.pp
 
 install:
 	$(MAKE) -C udev install
 	$(MAKE) -C qrexec-lib install
 	$(MAKE) -C qmemman install
 	$(MAKE) -C imgconverter install
+
+install-selinux:
+	install -m 0644 -D -t $(DESTDIR)/usr/share/selinux/packages selinux/qubes-meminfo-writer.pp
+	install -m 0644 -D selinux/qubes-meminfo-writer.if $(DESTDIR)/usr/share/selinux/devel/include/contrib/ipp-qubes-meminfo-writer.if
 
 install-fedora-kernel-support:
 	$(MAKE) -C dracut install
@@ -31,5 +38,6 @@ clean:
 	$(MAKE) -C qrexec-lib clean
 	$(MAKE) -C qmemman clean
 	$(MAKE) -C imgconverter clean
+	rm -rf selinux/*.pp selinux/tmp/
 	rm -rf debian/changelog.*
 	rm -rf pkgs

--- a/dracut/simple/init.sh
+++ b/dracut/simple/init.sh
@@ -103,7 +103,7 @@ if ! [ -d "$NEWROOT/lib/modules/$kver/kernel" ]; then
         if ! [ -d "$NEWROOT/lib/.modules_work" ]; then
             mkdir -p "$NEWROOT/lib/.modules_work"
         fi
-        mount -t overlay none $NEWROOT/lib/modules -o lowerdir=/tmp/modules,upperdir=$NEWROOT/lib/modules,workdir=$NEWROOT/lib/.modules_work
+        mount -t overlay none "$NEWROOT/lib/modules" -o "lowerdir=/tmp/modules,upperdir=$NEWROOT/lib/modules,workdir=$NEWROOT/lib/.modules_work"
     else
         # otherwise mount only `uname -r` subdirectory, to leave the rest of
         # /lib/modules writable

--- a/rpm_spec/qubes-utils.spec.in
+++ b/rpm_spec/qubes-utils.spec.in
@@ -12,6 +12,7 @@ Requires:	udev
 Requires:	%{name}-libs
 Requires:	GraphicsMagick
 Requires:	python%{python3_pkgversion}-qubesimgconverter
+Requires:	(%{name}-selinux if selinux-policy)
 %{?systemd_requires}
 BuildRequires:  systemd
 BuildRequires:  python%{python3_pkgversion}-setuptools
@@ -19,6 +20,7 @@ BuildRequires:  python3-rpm-macros
 # for meminfo-writer
 BuildRequires:  xen-devel
 BuildRequires:	gcc
+BuildRequires:  selinux-policy-devel
 
 %description
 Common Linux files for Qubes Dom0 and VM
@@ -48,14 +50,42 @@ Release:	1%{?dist}
 %description libs
 Libraries for qubes-utils
 
+%package selinux
+
+BuildRequires: selinux-policy
+%{?selinux_requires}
+
+Summary: SELinux policy for meminfo-writer
+License: GPLv2+
+
+%description selinux
+SELinux policy for meminfo-writer.  You need this package to run meminfo-writer
+on a system where SELinux is in enforcing mode.
+
+%post selinux
+%selinux_modules_install %{_datadir}/selinux/packages/qubes-meminfo-writer.pp || :
+
+%postun selinux
+if [ "$1" -eq 0 ]; then
+    %selinux_modules_uninstall %{_datadir}/selinux/packages/qubes-meminfo-writer.pp
+fi || :
+
+%posttrans selinux
+%selinux_relabel_post
+exit 0
+
+%files selinux
+%{_datadir}/selinux/packages/qubes-meminfo-writer.pp
+%{_datadir}/selinux/devel/include/contrib/ipp-qubes-meminfo-writer.if
+
 %prep
 %setup -q
 
 %build
-make all BACKEND_VMM=@BACKEND_VMM@ PYTHON=%{__python3}
+make all selinux BACKEND_VMM=@BACKEND_VMM@ PYTHON=%{__python3}
 
 %install
-make install DESTDIR=%{buildroot} PYTHON=%{__python3}
+make install install-selinux DESTDIR=%{buildroot} PYTHON=%{__python3}
 
 %post
 # dom0

--- a/selinux/qubes-meminfo-writer.fc
+++ b/selinux/qubes-meminfo-writer.fc
@@ -1,0 +1,2 @@
+/usr/sbin/meminfo-writer -- gen_context(system_u:object_r:qubes_meminfo_writer_exec_t,s0)
+/run/meminfo-writer\.pid -- gen_context(system_u:object_r:qubes_meminfo_writer_var_run_t,s0)

--- a/selinux/qubes-meminfo-writer.if
+++ b/selinux/qubes-meminfo-writer.if
@@ -1,0 +1,17 @@
+
+########################################
+## <summary>
+##	Communicate with meminfo-writer
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+interface(`qubes_meminfo_writer_signal',`
+	gen_require(``
+		type qubes_meminfo_writer_t, qubes_meminfo_writer_var_run_t;
+	'')`
+	allow '$1` qubes_meminfo_writer_t:process signal;
+	allow '$1` qubes_meminfo_writer_var_run_t:file 'read_file_perms;
+')

--- a/selinux/qubes-meminfo-writer.te
+++ b/selinux/qubes-meminfo-writer.te
@@ -1,0 +1,23 @@
+policy_module(qubes-meminfo-writer, 0.0.1)
+
+require {
+	type local_login_t, sysfs_t, proc_t;
+}
+
+type qubes_meminfo_writer_t;
+type qubes_meminfo_writer_exec_t;
+init_daemon_domain(qubes_meminfo_writer_t, qubes_meminfo_writer_exec_t)
+qubes_meminfo_writer_signal(local_login_t)
+allow qubes_meminfo_writer_t self:process { fork signal_perms };
+allow qubes_meminfo_writer_t self:fifo_file rw_fifo_file_perms;
+allow qubes_meminfo_writer_t { sysfs_t proc_t }:file { open read };
+files_read_etc_files(qubes_meminfo_writer_t)
+miscfiles_read_localization(qubes_meminfo_writer_t)
+dev_rw_xen(qubes_meminfo_writer_t)
+
+
+type qubes_meminfo_writer_var_run_t;
+files_pid_file(qubes_meminfo_writer_var_run_t)
+allow qubes_meminfo_writer_t var_run_t:dir { add_entry_dir_perms del_entry_dir_perms };
+allow qubes_meminfo_writer_t qubes_meminfo_writer_var_run_t:file { create_file_perms write_file_perms };
+files_pid_filetrans(`qubes_meminfo_writer_t', `qubes_meminfo_writer_var_run_t', `file', `"meminfo-writer.pid"')


### PR DESCRIPTION
This allows using meminfo-writer with SELinux enforcing.  Part of QubesOS/qubes-issues#4239.