### PR TITLE
initramfs: sector-size agnostic partitioning of volatile volume

### DIFF
--- a/dracut/full-dmroot/qubes_cow_setup.sh
+++ b/dracut/full-dmroot/qubes_cow_setup.sh
@@ -68,18 +68,19 @@ else
     ROOT_DEV=xvda
 fi
 
-SWAP_SIZE=$(( 1024 * 1024 * 2 )) # sectors, 1GB
+SWAP_SIZE_GiB=1
+SWAP_SIZE_512B=$(( SWAP_SIZE_GiB * 1024 * 1024 * 2 ))
 
 if [ `cat /sys/class/block/$ROOT_DEV/ro` = 1 ] ; then
     log_begin "Qubes: Doing COW setup for AppVM..."
 
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
-    VOLATILE_SIZE=$(cat /sys/class/block/xvdc/size) # sectors
-    if [ $VOLATILE_SIZE -lt $SWAP_SIZE ]; then
-        die "volatile.img smaller than 1GB, cannot continue"
+    VOLATILE_SIZE_512B=$(cat /sys/class/block/xvdc/size)
+    if [ $VOLATILE_SIZE_512B -lt $SWAP_SIZE_512B ]; then
+        die "volatile.img smaller than $SWAP_SIZE_GiB GiB, cannot continue"
     fi
-    sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-xvdc1: type=82,start=2048,size=$SWAP_SIZE
+    sfdisk -q /dev/xvdc >/dev/null <<EOF
+xvdc1: type=82,start=1MiB,size=${SWAP_SIZE_GiB}GiB
 xvdc2: type=83
 EOF
     if [ $? -ne 0 ]; then
@@ -99,8 +100,8 @@ EOF
 else
     log_begin "Qubes: Doing R/W setup for TemplateVM..."
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
-    sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-xvdc1: type=82,start=2048,size=$SWAP_SIZE
+    sfdisk -q /dev/xvdc >/dev/null <<EOF
+xvdc1: type=82,start=1MiB,size=${SWAP_SIZE_GiB}GiB
 xvdc3: type=83
 EOF
     if [ $? -ne 0 ]; then

--- a/dracut/full-dmroot/qubes_cow_setup.sh
+++ b/dracut/full-dmroot/qubes_cow_setup.sh
@@ -75,7 +75,6 @@ if [ `cat /sys/class/block/$ROOT_DEV/ro` = 1 ] ; then
 
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
     VOLATILE_SIZE=$(cat /sys/class/block/xvdc/size) # sectors
-    ROOT_SIZE=$(cat /sys/class/block/$ROOT_DEV/size) # sectors
     if [ $VOLATILE_SIZE -lt $SWAP_SIZE ]; then
         die "volatile.img smaller than 1GB, cannot continue"
     fi

--- a/dracut/simple/init.sh
+++ b/dracut/simple/init.sh
@@ -42,18 +42,19 @@ else
     ROOT_DEV=xvda
 fi
 
-SWAP_SIZE=$(( 1024 * 1024 * 2 )) # sectors, 1GB
+SWAP_SIZE_GiB=1
+SWAP_SIZE_512B=$(( SWAP_SIZE_GiB * 1024 * 1024 * 2 ))
 
 if [ `cat /sys/class/block/$ROOT_DEV/ro` = 1 ] ; then
     echo "Qubes: Doing COW setup for AppVM..."
 
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
-    VOLATILE_SIZE=$(cat /sys/class/block/xvdc/size) # sectors
-    if [ $VOLATILE_SIZE -lt $SWAP_SIZE ]; then
-        die "volatile.img smaller than 1GB, cannot continue"
+    VOLATILE_SIZE_512B=$(cat /sys/class/block/xvdc/size)
+    if [ $VOLATILE_SIZE_512B -lt $SWAP_SIZE_512B ]; then
+        die "volatile.img smaller than $SWAP_SIZE_GiB GiB, cannot continue"
     fi
-    /sbin/sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-xvdc1: type=82,start=2048,size=$SWAP_SIZE
+    /sbin/sfdisk -q /dev/xvdc >/dev/null <<EOF
+xvdc1: type=82,start=1MiB,size=${SWAP_SIZE_GiB}GiB
 xvdc2: type=83
 EOF
     if [ $? -ne 0 ]; then
@@ -71,8 +72,8 @@ EOF
 else
     echo "Qubes: Doing R/W setup for TemplateVM..."
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
-    /sbin/sfdisk -q --unit S /dev/xvdc >/dev/null <<EOF
-xvdc1: type=82,start=2048,size=$SWAP_SIZE
+    /sbin/sfdisk -q /dev/xvdc >/dev/null <<EOF
+xvdc1: type=82,start=1MiB,size=${SWAP_SIZE_GiB}GiB
 xvdc3: type=83
 EOF
     if [ $? -ne 0 ]; then

--- a/dracut/simple/init.sh
+++ b/dracut/simple/init.sh
@@ -49,7 +49,6 @@ if [ `cat /sys/class/block/$ROOT_DEV/ro` = 1 ] ; then
 
     while ! [ -e /dev/xvdc ]; do sleep 0.1; done
     VOLATILE_SIZE=$(cat /sys/class/block/xvdc/size) # sectors
-    ROOT_SIZE=$(cat /sys/class/block/$ROOT_DEV/size) # sectors
     if [ $VOLATILE_SIZE -lt $SWAP_SIZE ]; then
         die "volatile.img smaller than 1GB, cannot continue"
     fi


### PR DESCRIPTION
If the volatile volume is presented to the VM as a 4K sector device (which this PR does *not* do - but I tested it by [patching](https://gist.github.com/rustybird/691f78e112c64ed296f4e990fc5b2ef4) `/etc/xen/scripts/block` on a file-reflink installation), ensure that it won't result in nonsensical partitioning.

https://forum.qubes-os.org/t/ssd-maximal-performance-native-sector-size-partition-alignment/10189/30