### PR TITLE
Fix multiple bugs in block script

### DIFF
--- a/not-script/Makefile
+++ b/not-script/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS := $(CFLAGS) -g3 -O2 -Wall -Wextra -Werror -fPIE -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE
+CFLAGS := $(CFLAGS) -g3 -O2 -Wall -Wextra -Werror -fPIE -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -Wmaybe-uninitialized
 .PHONY: clean install all
 all: not-script
 
@@ -7,7 +7,7 @@ all: not-script
 	 s=$$(pkg-config --cflags --libs xenstore) && $(CC) $(CFLAGS) -MD -MP -MF $@.dep -o $@ $< $$s
 
 clean:
-	rm -f ./*.o ./*~ ./*.a ./*.so.* ./*.dep unicode-class-table.c
+	rm -f ./*.o ./*~ ./*.a ./*.so.* ./*.dep not-script
 
 install:
 	install -d $(DESTDIR)/etc/xen/scripts


### PR DESCRIPTION
- The remove path used 'end_path' uninitialized and so had completely undefined behavior.
- 'make clean' did not remove the executable 'not-script'.

Also add '-Wmaybe-uninitialized' and suppress a static analyzer warning.

Fixes: 94066d9c61c93152b5c1e55b44ba493fda8d58b5 ("Always write "diskseq" entry")
Reported-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>