### PR TITLE
initramfs: Handle the case where device-mapper is a module

### DIFF
--- a/dracut/simple/init.sh
+++ b/dracut/simple/init.sh
@@ -11,8 +11,12 @@ if [ -w /sys/devices/system/xen_memory/xen_memory0/scrub_pages ]; then
     echo 1 > /sys/devices/system/xen_memory/xen_memory0/scrub_pages
 fi
 
-if [ -e /dev/mapper/dmroot ] ; then 
-    echo "Qubes: FATAL error: /dev/mapper/dmroot already exists?!"
+# If device-mapper is built-in then Linux creates /dev/mapper,
+# but if it is a module then this script must do that.
+if [ ! -d /dev/mapper ]; then
+    mkdir -m 0755 /dev/mapper
+elif [ -e /dev/mapper/dmroot ]; then
+    echo "Qubes: FATAL error: /dev/mapper/dmroot already exists?!" >&2
 fi
 
 /sbin/modprobe xenblk || /sbin/modprobe xen-blkfront || echo "Qubes: Cannot load Xen Block Frontend..."


### PR DESCRIPTION
Qubes OS-provided kernels have device-mapper builtin, but it can also be built as a module, in which case /dev/mapper will not exist until the module is loaded or userspace creates the directory.  If the root volume is writable, this causes mounting /sysroot to fail, which in turn causes switch_root to fail with a confusing error.  This causes Linux to panic with "Attempted to kill init!".  Avoid this problems by explicitly creating /dev/mapper if it does not already exist.

Fixes: QubesOS/qubes-issues#8220