### PR TITLE
Stricter symbolic link checks

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,4 +1,3 @@
 Pillow
 numpy
-asynctest
 coverage

--- a/imgconverter/qubesimgconverter/test.py
+++ b/imgconverter/qubesimgconverter/test.py
@@ -8,11 +8,10 @@ except ImportError:
     from cStringIO import StringIO as BytesIO
 import unittest
 
-import asynctest
 
 import qubesimgconverter
 
-class TestCaseImage(asynctest.TestCase):
+class TestCaseImage(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.rgba = \
             b'\x00\x00\x00\xff' b'\xff\x00\x00\xff' \

--- a/qrexec-lib/Makefile
+++ b/qrexec-lib/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CFLAGS := $(CFLAGS) -I. -g3 -O2 -Wall -Wextra -Werror -pie -fPIC
 SO_VER=2
-LDFLAGS+=-Wl,--no-undefined,--as-needed
+LDFLAGS+=-Wl,--no-undefined,--as-needed -L .
 .PHONY: all clean install check
 objs := ioall.o copy-file.o crc32.o unpack.o pack.o
 
@@ -13,7 +13,7 @@ all: libqubes-rpc-filecopy.so.$(SO_VER) $(pure_lib).$(pure_sover)
 libqubes-rpc-filecopy.so.$(SO_VER): $(objs) ./$(pure_lib).$(pure_sover)
 	$(CC) -shared $(LDFLAGS) -Wl,-soname,$@ -o $@ $^
 validator-test: validator-test.o ./$(pure_lib).$(pure_sover)
-	libs=$$(pkg-config --libs icu-uc) && $(CC) $(LDFLAGS) -o $@ $^ $$libs
+	libs=$$(pkg-config --libs icu-uc) && $(CC) '-Wl,-rpath,$$ORIGIN' $(LDFLAGS) -o $@ $^ $$libs
 $(pure_objs): CFLAGS += -fvisibility=hidden -DQUBES_PURE_IMPLEMENTATION
 validator-test: CFLAGS += -UNDEBUG
 check: validator-test

--- a/qrexec-lib/pure.h
+++ b/qrexec-lib/pure.h
@@ -145,8 +145,8 @@ qubes_pure_validate_symbolic_link(const uint8_t *untrusted_name,
  * an assertion failure.
  */
 QUBES_PURE_PUBLIC bool
-qubes_pure_check_string_safe_for_display(const char *untrusted_str,
-                                         size_t line_length);
+qubes_pure_string_safe_for_display(const char *untrusted_str,
+                                   size_t line_length);
 
 /** Initialize a QubesSlice from a nul-terminated string. */
 static inline struct QubesSlice

--- a/qrexec-lib/unicode.c
+++ b/qrexec-lib/unicode.c
@@ -161,7 +161,7 @@ qubes_pure_validate_symbolic_link(const uint8_t *untrusted_name,
 }
 
 QUBES_PURE_PUBLIC bool
-qubes_pure_string_safe_for_display(const uint8_t *untrusted_str __attribute__((unused)), size_t line_length __attribute__((unused)))
+qubes_pure_string_safe_for_display(const char *untrusted_str, size_t line_length)
 {
     assert(line_length == 0 && "Not yet implemented: nonzero line length");
     size_t i = 0;
@@ -169,7 +169,7 @@ qubes_pure_string_safe_for_display(const uint8_t *untrusted_str __attribute__((u
         if (untrusted_str[i] >= 0x20 && untrusted_str[i] <= 0x7E) {
             i++;
         } else {
-            int utf8_ret = validate_utf8_char(untrusted_str + i);
+            int utf8_ret = validate_utf8_char((const uint8_t *)(untrusted_str + i));
             if (utf8_ret > 0) {
                 i += utf8_ret;
             } else {

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -116,6 +116,16 @@ int main(int argc, char **argv)
         assert(!qubes_pure_validate_file_name(buf));
     }
 
+    // Invalid codepoints beyond 0x10FFFFF are forbidden
+    for (uint32_t i = 0x90; i < 0xC0; ++i) {
+        for (uint32_t j = 0x80; j < 0xC0; ++j) {
+            for (uint32_t k = 0x80; k < 0xC0; ++k) {
+                char buf[5] = { 0xF4, i, j, k, 0 };
+                assert(!qubes_pure_string_safe_for_display(buf, 0));
+            }
+        }
+    }
+
     // Directory traversal checks
     assert(!qubes_pure_validate_file_name((uint8_t *)".."));
     assert(!qubes_pure_validate_file_name((uint8_t *)"../.."));

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -9,30 +9,30 @@
 #endif
 #include <assert.h>
 
-static void character_must_be_allowed(uint32_t c)
+static void character_must_be_allowed(UChar32 c)
 {
-    uint8_t buf[5];
+    char buf[5];
     int32_t off = 0;
     UBool e = false;
-    U8_APPEND(buf, off, 4, c, e);
+    U8_APPEND((uint8_t *)buf, off, 4, c, e);
     assert(!e && off <= 4);
     buf[off] = 0;
-    if (!qubes_pure_validate_file_name(buf)) {
-        fprintf(stderr, "BUG: cannot handle file name %s (codepoint U+%" PRIx32 ")\n", buf, c);
+    if (!qubes_pure_string_safe_for_display(buf, 0)) {
+        fprintf(stderr, "BUG: cannot handle file name %s (codepoint U+%" PRIx32 ")\n", buf, (int32_t)c);
         abort();
     }
 }
 
-static void character_must_be_forbidden(uint32_t c)
+static void character_must_be_forbidden(UChar32 c)
 {
-    uint8_t buf[5];
+    char buf[5];
     int32_t off = 0;
     UBool e = false;
-    U8_APPEND(buf, off, 4, c, e);
+    U8_APPEND((uint8_t *)buf, off, 4, c, e);
     assert(!e && off <= 4);
     buf[off] = 0;
-    if (qubes_pure_validate_file_name(buf)) {
-        fprintf(stderr, "BUG: allowed file name with codepoint U+%" PRIx32 "\n", c);
+    if (qubes_pure_string_safe_for_display(buf, 0)) {
+        fprintf(stderr, "BUG: allowed file name with codepoint U+%" PRIx32 "\n", (int32_t)c);
         abort();
     }
 }
@@ -98,22 +98,26 @@ int main(int argc, char **argv)
     }
 
     // Flags are too complex to display :(
-    assert(!qubes_pure_validate_file_name((uint8_t *)u8"\U0001f3f3"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)u8"\ufe0f"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)u8"\u200d"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)u8"\u26a0"));
+    assert(!qubes_pure_string_safe_for_display(u8"\U0001f3f3", 0));
+    assert(!qubes_pure_string_safe_for_display(u8"\ufe0f", 0));
+    assert(!qubes_pure_string_safe_for_display(u8"\u200d", 0));
+    assert(!qubes_pure_string_safe_for_display(u8"\u26a0", 0));
 
     // Emojies are not allowed
-    assert(!qubes_pure_validate_file_name((uint8_t *)u8"\U0001f642"));
+    assert(!qubes_pure_string_safe_for_display(u8"\U0001f642", 0));
     // Cuneiform is way too obscure to be worth the risk
-    assert(!qubes_pure_validate_file_name((uint8_t *)u8"\U00012000"));
+    assert(!qubes_pure_string_safe_for_display(u8"\U00012000", 0));
     // Surrogates are forbidden
     for (uint32_t i = 0xD800; i <= 0xDFFF; ++i) {
-        uint8_t buf[4] = { 0, 0, 0, 0 };
-        int32_t off = 0;
-        U8_APPEND_UNSAFE(buf, off, i);
-        assert(off == 3);
-        assert(!qubes_pure_validate_file_name(buf));
+        uint8_t buf[4] = {
+            i >> 12 | 0xE0,
+            0x80 | (i >> 6 & 0x3F),
+            0x80 | (i & 0x3F),
+            0,
+        };
+        assert(buf[0] == 0xED);
+        assert(buf[1] >= 0xA0 && buf[1] <= 0xBF);
+        assert(!qubes_pure_string_safe_for_display((char *)buf, 0));
     }
 
     // Invalid codepoints beyond 0x10FFFFF are forbidden

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -144,6 +144,18 @@ int main(int argc, char **argv)
     assert(!qubes_pure_validate_file_name((uint8_t *)"a/../a"));
 
     // Looks like "." or ".." but is not
-    assert(qubes_pure_validate_file_name((uint8_t *)".a"));
-    assert(qubes_pure_validate_file_name((uint8_t *)"..a"));
+    assert(qubes_pure_validate_file_name((const uint8_t *)".a"));
+    assert(qubes_pure_validate_file_name((const uint8_t *)"..a"));
+
+    // Symbolic links
+    // Top level cannot be symlink
+    assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"a", (const uint8_t *)"b"));
+    // Symbolic links cannot escape
+    assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"a/b", (const uint8_t *)"../a"));
+    assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"a/b", (const uint8_t *)"../a/b/c"));
+    assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"../../a"));
+    assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b", (const uint8_t *)"a"));
+    assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"../a"));
+    // Absolute symlinks are rejected
+    assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"/a"));
 }


### PR DESCRIPTION
A copied symbolic link should not be able to escape the directory tree it is in.  This means that top-level symbolic links must be rejected, and that a link named a/b/c must be allowed to point to ../b (which would resolve to a/b) but not ../../b (which would resole to b).  This ensures that users can write to directory trees copied by qvm-copy without worrying about a symlink attack causing them to write to a different location in their filesystem, even if the directory tree has been moved out of ~/QubesIncoming/VMNAME.