### PR TITLE
debian: reduce initramfs size

### DIFF
--- a/debian/qubes-kernel-vm-support.install
+++ b/debian/qubes-kernel-vm-support.install
@@ -1,3 +1,4 @@
+usr/share/initramfs-tools/conf.d/qubes.conf
 usr/share/initramfs-tools/scripts/local-top/scrub_pages
 usr/share/initramfs-tools/scripts/local-top/qubes_cow_setup
 usr/share/initramfs-tools/hooks/qubes_vm

--- a/initramfs-tools/Makefile
+++ b/initramfs-tools/Makefile
@@ -5,4 +5,6 @@ install:
 		$(DESTDIR)/usr/share/initramfs-tools/scripts/local-top/scrub_pages
 	install -D qubes_vm \
 		$(DESTDIR)/usr/share/initramfs-tools/hooks/qubes_vm
+	install -m 0644 -D qubes.conf \
+		$(DESTDIR)/usr/share/initramfs-tools/conf.d/qubes.conf
 	

--- a/initramfs-tools/qubes.conf
+++ b/initramfs-tools/qubes.conf
@@ -1,0 +1,4 @@
+# reduce initramfs size
+MODULES=dep
+# there is no suspend-to-disk for VMs
+RESUME=none


### PR DESCRIPTION
Build initramfs with only required modules, not all of them. Otherwise
it's too big to boot with default 400M.
Additionally disable looking for suspend-to-disk signature, this feature
is never used on Qubes VM (swap device is not persistent).

Fixes QubesOS/qubes-issues#8277