### PR TITLE
Depend on busybox _or_ busybox-static

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Description: Qubes Linux utilities
 Package: qubes-kernel-vm-support
 Architecture: any
 Depends:
- busybox,
+ busybox | busybox-static,
  initramfs-tools | dracut,
  grub2-common,
  ${misc:Depends}


### PR DESCRIPTION
This ensures that installing a package that requires busybox-static, such as waydroid or lxc, does not cause qubes-kernel-vm-support to be removed.

Reported-by: Patrick Schleizer <adrelanos@whonix.org>
Fixes: QubesOS/qubes-issues#8377