### PR TITLE
debian: split libqubes-pure into separate package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,6 +54,23 @@ Description: Development headers for libqrexec-utils
  This package contains files required to compile Qubes file copy related
  utilities like qfile-agent.
 
+Package: libqubes-pure0
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Breaks: libqubes-rpc-filecopy2 (<< 4.2.12)
+Replaces: libqubes-rpc-filecopy2 (<< 4.2.12)
+Description: Qubes file copy protocol library
+ Utility library with qubes-specific functions.
+
+Package: libqubes-pure-dev
+Architecture: any
+Section: libdevel
+Depends: libqubes-pure0 (= ${binary:Version}), ${misc:Depends}
+Breaks: libqubes-rpc-filecopy-dev (<< 4.2.12)
+Replaces: libqubes-rpc-filecopy-dev (<< 4.2.12)
+Description: Development headers for libqrexec-utils
+ Utility library with qubes-specific functions - headers
+
 Package: python3-qubesimgconverter
 Architecture: any
 Depends: python3-cairo, python3-pil, python3-numpy, ${misc:Depends}

--- a/debian/libqubes-pure-dev.install
+++ b/debian/libqubes-pure-dev.install
@@ -1,0 +1,2 @@
+usr/include/qubes/pure.h
+usr/lib/libqubes-pure.so

--- a/debian/libqubes-pure0.install
+++ b/debian/libqubes-pure0.install
@@ -1,0 +1,1 @@
+usr/lib/libqubes-pure.so.0*

--- a/debian/libqubes-pure0.shlibs
+++ b/debian/libqubes-pure0.shlibs
@@ -1,0 +1,1 @@
+libqubes-pure 0 libqubes-pure0 (>= 4.2.12)

--- a/debian/libqubes-rpc-filecopy-dev.install
+++ b/debian/libqubes-rpc-filecopy-dev.install
@@ -1,4 +1,2 @@
 usr/include/libqubes-rpc-filecopy.h
-usr/include/qubes/pure.h
 usr/lib/libqubes-rpc-filecopy.so
-usr/lib/libqubes-pure.so

--- a/debian/libqubes-rpc-filecopy2.install
+++ b/debian/libqubes-rpc-filecopy2.install
@@ -1,2 +1,1 @@
 usr/lib/libqubes-rpc-filecopy.so.2*
-usr/lib/libqubes-pure.so.0*

--- a/debian/libqubes-rpc-filecopy2.shlibs
+++ b/debian/libqubes-rpc-filecopy2.shlibs
@@ -1,2 +1,1 @@
 libqubes-rpc-filecopy 2 libqubes-rpc-filecopy2 (>= 4.1.7)
-libqubes-pure 0 libqubes-rpc-filecopy2 (>= 4.2.0)


### PR DESCRIPTION
Combining it with libqubes-rpc-filecopy doesn't make much sense. Debian
recommends packaging each (separately so-versioned) library as a
separate package.