### PR TITLE
Avoid writing junk into Xenstore

### DIFF
--- a/not-script/not-script.c
+++ b/not-script/not-script.c
@@ -487,8 +487,9 @@ int main(int argc, char **argv)
     char buf[sizeof("/dev/loop") + 10];
     char *physdev_path = data;
     if (major(dev) == LOOP_MAJOR) {
-        if ((unsigned)snprintf(buf, sizeof buf, "/dev/loop%" PRIu32,
-                               (unsigned)minor(dev)) >= sizeof buf)
+        path_len = (unsigned)snprintf(buf, sizeof buf, "/dev/loop%" PRIu32,
+                                      (unsigned)minor(dev));
+        if (path_len >= sizeof buf)
             abort();
         physdev_path = buf;
     }


### PR DESCRIPTION
The path buffer pointer would be overwritten, but the length would not be.  xs_write() would therefore read out of bounds.

This is not a security problem as the not-script process has no secrets in its address space, and besides it is not exposed to untrusted input.

Not tested beyond "it builds", but should be quite obvious.

Fixes: QubesOS/qubes-issues#8708