### PR TITLE
RFC: Add C API to check a qrexec target

### DIFF
--- a/qrexec-lib/pure.h
+++ b/qrexec-lib/pure.h
@@ -191,6 +191,8 @@ enum QubeNameValidationError {
     /// Name is `none`, `default`, `Domain-0`, or ends in `-dm`.
     /// These names are reserved.
     QUBE_NAME_RESERVED = -6,
+    /// Prefix of qrexec target is invalid.
+    QREXEC_TARGET_INVALID_PREFIX = -7,
 };
 
 /**
@@ -209,6 +211,21 @@ enum QubeNameValidationError {
  */
 QUBES_PURE_PUBLIC enum QubeNameValidationError
 qubes_pure_is_valid_qube_name(const struct QubesSlice untrusted_str);
+
+/**
+ * Validate that `untrusted_str` is a valid qrexec target.  A valid qrexec
+ * target is one of the following, where `QUBE_NAME` can be any valid qube name.
+ *
+ * - `@adminvm`
+ * - `@default`
+ * - `@dispvm`
+ * - `@dispvm:QUBE_NAME`
+ * - `QUBE_NAME`
+ * - `QUBE_NAME-dm`
+ */
+QUBES_PURE_PUBLIC enum QubeNameValidationError
+qubes_pure_is_valid_qrexec_target(const struct QubesSlice untrusted_str);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The intended use of this function is in qrexec's C code, to determine if a qrexec target could possibly be valid before the Python policy engine ever sees it.  I'm marking this as RFC for a couple of reasons:

1. It might be a bad idea to begin with.  The goal is to prevent the Python code from getting bad data in the first place, but the Python code is supposed to be robust to that.  It could also be used from Python to make sure that certain entries in qrexec policy aren't junk, but that might be better handled in pure Python, rather than with an FFI call.

2. There are no unit tests or fuzz harnesses.  This is easy to fix, but I do not want to put in the work if this code won't be used.