### PR TITLE
Allow disabling character set filtering

### DIFF
--- a/qrexec-lib/Makefile
+++ b/qrexec-lib/Makefile
@@ -15,6 +15,9 @@ libqubes-rpc-filecopy.so.$(SO_VER): $(objs) ./$(pure_lib).$(pure_sover)
 validator-test: validator-test.o ./$(pure_lib).$(pure_sover)
 	libs=$$(pkg-config --libs icu-uc) && $(CC) '-Wl,-rpath,$$ORIGIN' $(LDFLAGS) -o $@ $^ $$libs
 $(pure_objs): CFLAGS += -fvisibility=hidden -DQUBES_PURE_IMPLEMENTATION
+ifeq ($(CHECK_UNREACHABLE),1)
+$(pure_objs): CFLAGS += -DCHECK_UNREACHABLE
+endif
 validator-test: CFLAGS += -UNDEBUG
 check: validator-test
 	LD_LIBRARY_PATH=. ./validator-test

--- a/qrexec-lib/Makefile
+++ b/qrexec-lib/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS := $(CFLAGS) -I. -g3 -O2 -Wall -Wextra -Werror -pie -fPIC
+CFLAGS := $(CFLAGS) -I. -g3 -O2 -Wall -Wextra -Werror -pie -fPIC -Wmissing-declarations -Wmissing-prototypes
 SO_VER=2
 LDFLAGS+=-Wl,--no-undefined,--as-needed,-Bsymbolic -L .
 .PHONY: all clean install check

--- a/qrexec-lib/crc32.c
+++ b/qrexec-lib/crc32.c
@@ -31,46 +31,6 @@ unsigned long Crc32_ComputeBuf( unsigned long inCrc32, const void *buf,
 
 /*----------------------------------------------------------------------------*\
  *  NAME:
- *     Crc32_ComputeFile() - compute CRC-32 value for a file
- *  DESCRIPTION:
- *     Computes the CRC-32 value for an opened file.
- *  ARGUMENTS:
- *     file - file pointer
- *     outCrc32 - (out) result CRC-32 value
- *  RETURNS:
- *     err - 0 on success or -1 on error
- *  ERRORS:
- *     - file errors
-\*----------------------------------------------------------------------------*/
-
-int Crc32_ComputeFile( FILE *file, unsigned long *outCrc32 )
-{
-#   define CRC_BUFFER_SIZE  8192
-    unsigned char buf[CRC_BUFFER_SIZE];
-    size_t bufLen;
-
-    /** accumulate crc32 from file **/
-    *outCrc32 = 0;
-    while (1) {
-        bufLen = fread( buf, 1, CRC_BUFFER_SIZE, file );
-        if (bufLen == 0) {
-            if (ferror(file)) {
-                fprintf( stderr, "error reading file\n" );
-                goto ERR_EXIT;
-            }
-            break;
-        }
-        *outCrc32 = Crc32_ComputeBuf( *outCrc32, buf, bufLen );
-    }
-    return( 0 );
-
-    /** error exit **/
-ERR_EXIT:
-    return( -1 );
-}
-
-/*----------------------------------------------------------------------------*\
- *  NAME:
  *     Crc32_ComputeBuf() - computes the CRC-32 value of a memory buffer
  *  DESCRIPTION:
  *     Computes or accumulates the CRC-32 value for a memory buffer.

--- a/qrexec-lib/ioall.c
+++ b/qrexec-lib/ioall.c
@@ -24,8 +24,9 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
+#include "libqubes-rpc-filecopy.h"
 
-void perror_wrapper(const char * msg)
+static void perror_wrapper(const char * msg)
 {
     int prev=errno;
     perror(msg);

--- a/qrexec-lib/libqubes-rpc-filecopy.h
+++ b/qrexec-lib/libqubes-rpc-filecopy.h
@@ -69,6 +69,7 @@ enum copy_flags {
     COPY_ALLOW_DIRECTORIES = (1 << 1),
     COPY_ALLOW_UNSAFE_CHARACTERS = (1 << 2),
     COPY_ALLOW_NON_CANONICAL_SYMLINKS = (1 << 3),
+    COPY_ALLOW_UNSAFE_SYMLINKS = (1 << 4),
 };
 
 /* feedback handling */

--- a/qrexec-lib/libqubes-rpc-filecopy.h
+++ b/qrexec-lib/libqubes-rpc-filecopy.h
@@ -68,6 +68,7 @@ enum copy_flags {
     COPY_ALLOW_SYMLINKS = (1 << 0),
     COPY_ALLOW_DIRECTORIES = (1 << 1),
     COPY_ALLOW_UNSAFE_CHARACTERS = (1 << 2),
+    COPY_ALLOW_NON_CANONICAL_SYMLINKS = (1 << 3),
 };
 
 /* feedback handling */

--- a/qrexec-lib/libqubes-rpc-filecopy.h
+++ b/qrexec-lib/libqubes-rpc-filecopy.h
@@ -67,6 +67,7 @@ enum copy_flags {
     COPY_DEFAULT = 0,
     COPY_ALLOW_SYMLINKS = (1 << 0),
     COPY_ALLOW_DIRECTORIES = (1 << 1),
+    COPY_ALLOW_UNSAFE_CHARACTERS = (1 << 2),
 };
 
 /* feedback handling */

--- a/qrexec-lib/pack.c
+++ b/qrexec-lib/pack.c
@@ -107,6 +107,16 @@ void wait_for_result(void)
             case EINVAL:
                 call_error_handler("File copy: Corrupted data from packer%s\"%s\"", last_filename_prefix, last_filename);
                 break;
+            case EILSEQ:
+                call_error_handler("Forbidden character in file or link target. Name might look somewhat like \"%s\"", last_filename);
+                break;
+            case ENOLINK:
+                // FIXME: the protocol only provides the name of the file, not what it points to.
+                // FIXME: This assumes that a symlink target was rejected, not a path.  However,
+                // this code should only produces valid paths, so if an invalid path gets sent,
+                // that's a bug.
+                call_error_handler("Cannot verify that link at \"%s\" would not be broken by copy", last_filename);
+                break;
             case EDQUOT:
                 if (ignore_quota_error) {
                     /* skip also CRC check as sender and receiver might be

--- a/qrexec-lib/pure.h
+++ b/qrexec-lib/pure.h
@@ -93,10 +93,30 @@ struct QubesMutableSlice {
  * filenames are also rejected, including invalid UTF-8 sequences and
  * all control characters.  The input must be NUL-terminated.
  *
- * Returns true on success and false on failure.
+ * \param[in] untrusted_path The path to be checked.
+ * \return \true on success and \false on failure.
+ *
+ * This is equivalent to passing zero for the flags parameter
+ * to qubes_pure_validate_file_name_v2() and checking that
+ * the result is zero.
  */
 QUBES_PURE_PUBLIC bool
-qubes_pure_validate_file_name(const uint8_t *untrusted_filename);
+qubes_pure_validate_file_name(const uint8_t *untrusted_path);
+
+/**
+ * Validate that a string is a valid path and will not result in
+ * directory traversal if used as such.  If flags does not include
+ * \ref QUBES_PURE_ALLOW_UNSAFE_CHARACTERS, characters that are unsafe for
+ * filenames are also rejected, including invalid UTF-8 sequences and
+ * all control characters.  The input must be NUL-terminated.
+ *
+ * \param[in] untrusted_path The path to be checked.
+ * \param flags 0 or QUBES_PURE_ALLOW_UNSAFE_CHARACTERS.
+ * \return 0 on success, negative errno value on failure.
+ */
+QUBES_PURE_PUBLIC int
+qubes_pure_validate_file_name_v2(const uint8_t *const untrusted_path,
+                                 const uint32_t flags);
 
 /**
  * Validate that `untrusted_name` is a valid symbolic link name
@@ -107,10 +127,33 @@ qubes_pure_validate_file_name(const uint8_t *untrusted_filename);
  * NUL-terminated.
  *
  * Returns true on success and false on failure.
+ *
+ * This is equivalent to passing zero for the flags parameter
+ * to qubes_pure_validate_symbolic_link_v2() and checking that
+ * the result is zero.
  */
 QUBES_PURE_PUBLIC bool
 qubes_pure_validate_symbolic_link(const uint8_t *untrusted_name,
                                   const uint8_t *untrusted_target);
+
+/**
+ * Validate that `untrusted_path` is a valid symbolic link name
+ * and that creating a symbolic link with that name and target
+ * `untrusted_target` is also safe.  If flags does not include
+ * \ref QUBES_PURE_ALLOW_UNSAFE_CHARACTERS, characters that are unsafe for
+ * filenames are also rejected, including invalid UTF-8 sequences and
+ * all control characters.  The input must be NUL-terminated.
+ *
+ * \param[in] untrusted_path The path to be checked.
+ * \param[in] untrusted_target The proposed target for the symbolic link.
+ * \param flags 0 or QUBES_PURE_ALLOW_UNSAFE_CHARACTERS.
+ * \return 0 on success, negative errno value on failure.
+ */
+QUBES_PURE_PUBLIC int
+qubes_pure_validate_symbolic_link_v2(const uint8_t *untrusted_path,
+                                     const uint8_t *untrusted_target,
+                                     uint32_t flags);
+
 
 /**
  * Validate that `code_point` is safe to display.  To be considered safe to
@@ -209,6 +252,11 @@ enum QubeNameValidationError {
  */
 QUBES_PURE_PUBLIC enum QubeNameValidationError
 qubes_pure_is_valid_qube_name(const struct QubesSlice untrusted_str);
+
+enum QubesFilenameValidationFlags {
+    /// Disable Unicode charset restrictions and UTF-8 validity checks.
+    QUBES_PURE_ALLOW_UNSAFE_CHARACTERS = (1 << 0),
+};
 
 #ifdef __cplusplus
 }

--- a/qrexec-lib/pure.h
+++ b/qrexec-lib/pure.h
@@ -253,6 +253,7 @@ enum QubeNameValidationError {
 QUBES_PURE_PUBLIC enum QubeNameValidationError
 qubes_pure_is_valid_qube_name(const struct QubesSlice untrusted_str);
 
+/// Flags for pathname validation functions.
 enum QubesFilenameValidationFlags {
     /// Disable Unicode charset restrictions and UTF-8 validity checks.
     QUBES_PURE_ALLOW_UNSAFE_CHARACTERS = (1 << 0),
@@ -264,6 +265,8 @@ enum QubesFilenameValidationFlags {
     QUBES_PURE_ALLOW_UNSAFE_SYMLINKS = (1 << 2),
     /// Allow all paths to be non-canonical, including symlinks.
     QUBES_PURE_ALLOW_NON_CANONICAL_PATHS = (1 << 3),
+    /// Allow trailing slash.
+    QUBES_PURE_ALLOW_TRAILING_SLASH = (1 << 4),
 };
 
 #ifdef __cplusplus

--- a/qrexec-lib/pure.h
+++ b/qrexec-lib/pure.h
@@ -256,6 +256,12 @@ qubes_pure_is_valid_qube_name(const struct QubesSlice untrusted_str);
 enum QubesFilenameValidationFlags {
     /// Disable Unicode charset restrictions and UTF-8 validity checks.
     QUBES_PURE_ALLOW_UNSAFE_CHARACTERS = (1 << 0),
+    /// Allow non-canonical symbolic links.  Paths are still checked
+    /// to be canonial, as they are assumed to come from a filesystem
+    /// traversal, which will always produce canonical paths.
+    QUBES_PURE_ALLOW_NON_CANONICAL_SYMLINKS = (1 << 1),
+    /// Allow all paths to be non-canonical, including symlinks.
+    QUBES_PURE_ALLOW_NON_CANONICAL_PATHS = (1 << 3),
 };
 
 #ifdef __cplusplus

--- a/qrexec-lib/pure.h
+++ b/qrexec-lib/pure.h
@@ -260,6 +260,8 @@ enum QubesFilenameValidationFlags {
     /// to be canonial, as they are assumed to come from a filesystem
     /// traversal, which will always produce canonical paths.
     QUBES_PURE_ALLOW_NON_CANONICAL_SYMLINKS = (1 << 1),
+    /// Do not check symbolic links at all.
+    QUBES_PURE_ALLOW_UNSAFE_SYMLINKS = (1 << 2),
     /// Allow all paths to be non-canonical, including symlinks.
     QUBES_PURE_ALLOW_NON_CANONICAL_PATHS = (1 << 3),
 };

--- a/qrexec-lib/unicode-generator.c
+++ b/qrexec-lib/unicode-generator.c
@@ -283,6 +283,8 @@ static bool is_permitted_code_point(uint32_t const code_point)
     }
 }
 
+// Generate the table of allowed codepoints,
+// as a bunch of cases in a switch statement.
 static void print_code_point_list(FILE *out)
 {
     bool last_allowed = false;

--- a/qrexec-lib/unicode.c
+++ b/qrexec-lib/unicode.c
@@ -223,7 +223,8 @@ static bool flag_check(const uint32_t flags)
 {
     int const allowed = (QUBES_PURE_ALLOW_UNSAFE_CHARACTERS |
                          QUBES_PURE_ALLOW_NON_CANONICAL_SYMLINKS |
-                         QUBES_PURE_ALLOW_NON_CANONICAL_PATHS);
+                         QUBES_PURE_ALLOW_NON_CANONICAL_PATHS |
+                         QUBES_PURE_ALLOW_UNSAFE_SYMLINKS);
     return (flags & ~(__typeof__(flags))allowed) == 0;
 }
 
@@ -255,6 +256,8 @@ qubes_pure_validate_symbolic_link_v2(const uint8_t *untrusted_name,
     ssize_t depth = validate_path(untrusted_name, 0, flags);
     if (depth < 0)
         return -EILSEQ; // -ENOLINK is only for symlinks
+    if ((flags & QUBES_PURE_ALLOW_UNSAFE_SYMLINKS) != 0)
+        return depth > 0 ? 0 : -ENOLINK;
     if ((flags & QUBES_PURE_ALLOW_NON_CANONICAL_SYMLINKS) != 0)
         flags |= QUBES_PURE_ALLOW_NON_CANONICAL_PATHS;
     // Symlink paths must have at least 2 components: "a/b" is okay

--- a/qrexec-lib/unicode.c
+++ b/qrexec-lib/unicode.c
@@ -137,7 +137,7 @@ static ssize_t validate_path(const uint8_t *const untrusted_name, size_t allowed
         if (i == 0 || untrusted_name[i - 1] == '/') {
             switch (untrusted_name[i]) {
             case '/': // repeated or initial slash
-            case '\0': // trailing slash or empty string
+            case '\0': // empty string
                 return -1;
             case '.':
                 if (untrusted_name[i + 1] == '\0' || untrusted_name[i + 1] == '/')

--- a/qrexec-lib/unpack.c
+++ b/qrexec-lib/unpack.c
@@ -204,7 +204,7 @@ void process_one_file_reg(struct file_header *untrusted_hdr,
     const char *last_segment;
     char *path_dup;
 
-    if (!qubes_pure_validate_file_name((uint8_t *)untrusted_name))
+    if (!qubes_pure_validate_file_name((const uint8_t *)untrusted_name))
         do_exit(EILSEQ, untrusted_name); /* FIXME: better error message */
     if ((path_dup = strdup(untrusted_name)) == NULL)
         do_exit(ENOMEM, untrusted_name);
@@ -266,7 +266,7 @@ void process_one_file_dir(struct file_header *untrusted_hdr,
     int safe_dirfd;
     const char *last_segment;
     char *path_dup;
-    if (!qubes_pure_validate_file_name((uint8_t *)untrusted_name))
+    if (!qubes_pure_validate_file_name((const uint8_t *)untrusted_name))
         do_exit(EILSEQ, untrusted_name); /* FIXME: better error message */
     if ((path_dup = strdup(untrusted_name)) == NULL)
         do_exit(ENOMEM, untrusted_name);
@@ -298,7 +298,7 @@ void process_one_file_link(struct file_header *untrusted_hdr,
     const char *last_segment;
     char *path_dup;
     unsigned int filelen;
-    if (!qubes_pure_validate_file_name((uint8_t *)untrusted_name))
+    if (!qubes_pure_validate_file_name((const uint8_t *)untrusted_name))
         do_exit(EILSEQ, untrusted_name); /* FIXME: better error message */
     int safe_dirfd;
     if (untrusted_hdr->filelen > MAX_PATH_LENGTH - 1)
@@ -315,8 +315,8 @@ void process_one_file_link(struct file_header *untrusted_hdr,
      * Ensure that no immediate subdirectory of ~/QubesIncoming/VMNAME
      * may have symlinks that point out of it.
      */
-    if (!qubes_pure_validate_symbolic_link((uint8_t *)untrusted_name,
-                                           (uint8_t *)untrusted_content))
+    if (!qubes_pure_validate_symbolic_link((const uint8_t *)untrusted_name,
+                                           (const uint8_t *)untrusted_content))
         do_exit(EILSEQ, untrusted_content);
 
     if ((path_dup = strdup(untrusted_name)) == NULL)

--- a/qrexec-lib/unpack.c
+++ b/qrexec-lib/unpack.c
@@ -298,8 +298,6 @@ static void process_one_file_link(struct file_header *untrusted_hdr,
     const char *last_segment;
     char *path_dup;
     unsigned int filelen;
-    if (!qubes_pure_validate_file_name((const uint8_t *)untrusted_name))
-        do_exit(EILSEQ, untrusted_name); /* FIXME: better error message */
     int safe_dirfd;
     if (untrusted_hdr->filelen > MAX_PATH_LENGTH - 1)
         do_exit(ENAMETOOLONG, untrusted_name);
@@ -312,6 +310,7 @@ static void process_one_file_link(struct file_header *untrusted_hdr,
         do_exit(LEGAL_EOF, untrusted_name); // hopefully remote has produced error message
     untrusted_content[filelen] = 0;
     /*
+     * Sanitize both the path of the symbolic link and its target.
      * Ensure that no immediate subdirectory of ~/QubesIncoming/VMNAME
      * may have symlinks that point out of it.
      */

--- a/qrexec-lib/unpack.c
+++ b/qrexec-lib/unpack.c
@@ -45,7 +45,7 @@ void send_status_and_crc(int code, const char *last_filename);
 #define O_TMPFILE_MASK (__O_TMPFILE | O_DIRECTORY | O_CREAT)
 #endif
 
-_Noreturn void do_exit(int code, const char *last_filename)
+static _Noreturn void do_exit(int code, const char *last_filename)
 {
     close(0);
     send_status_and_crc(code, last_filename);
@@ -74,7 +74,7 @@ void set_procfs_fd(int value)
     use_tmpfile = 1;
 }
 
-int wait_for_space(int fd, unsigned long how_much) {
+static int wait_for_space(int fd, unsigned long how_much) {
     int counter = 0;
     struct statvfs fs_space;
     do {
@@ -91,7 +91,7 @@ int wait_for_space(int fd, unsigned long how_much) {
 }
 
 static unsigned long crc32_sum = 0;
-int read_all_with_crc(int fd, void *buf, int size) {
+static int read_all_with_crc(int fd, void *buf, int size) {
     int ret;
     ret = read_all(fd, buf, size);
     if (ret)
@@ -196,8 +196,8 @@ static int opendir_safe(int dirfd, char *path, const char **last_segment)
     }
 }
 
-void process_one_file_reg(struct file_header *untrusted_hdr,
-        const char *untrusted_name)
+static void process_one_file_reg(struct file_header *untrusted_hdr,
+                                 const char *untrusted_name)
 {
     int ret;
     int fdout = -1, safe_dirfd;
@@ -260,8 +260,8 @@ void process_one_file_reg(struct file_header *untrusted_hdr,
 }
 
 
-void process_one_file_dir(struct file_header *untrusted_hdr,
-        const char *untrusted_name)
+static void process_one_file_dir(struct file_header *untrusted_hdr,
+                                 const char *untrusted_name)
 {
     int safe_dirfd;
     const char *last_segment;
@@ -291,8 +291,8 @@ void process_one_file_dir(struct file_header *untrusted_hdr,
     free(path_dup);
 }
 
-void process_one_file_link(struct file_header *untrusted_hdr,
-        const char *untrusted_name)
+static void process_one_file_link(struct file_header *untrusted_hdr,
+                                  const char *untrusted_name)
 {
     char untrusted_content[MAX_PATH_LENGTH];
     const char *last_segment;
@@ -331,7 +331,7 @@ void process_one_file_link(struct file_header *untrusted_hdr,
     free(path_dup);
 }
 
-void process_one_file(struct file_header *untrusted_hdr, int flags)
+static void process_one_file(struct file_header *untrusted_hdr, int flags)
 {
     unsigned int namelen;
     if (untrusted_hdr->namelen > MAX_PATH_LENGTH - 1)

--- a/qrexec-lib/unpack.c
+++ b/qrexec-lib/unpack.c
@@ -343,7 +343,11 @@ static void process_one_file(struct file_header *untrusted_hdr, int flags)
     if (untrusted_hdr->namelen > MAX_PATH_LENGTH - 1)
         do_exit(ENAMETOOLONG, NULL); /* filename too long so not received at all */
     namelen = untrusted_hdr->namelen; /* sanitized above */
-    uint32_t validate_flags = ((uint32_t)flags >> 2) & (QUBES_PURE_ALLOW_UNSAFE_CHARACTERS);
+    // Never set QUBES_PURE_ALLOW_NON_CANONICAL_PATHS -- paths from qfile-agent
+    // will always be canonical.
+    uint32_t validate_flags = ((uint32_t)flags >> 2) &
+        (QUBES_PURE_ALLOW_UNSAFE_CHARACTERS |
+         QUBES_PURE_ALLOW_NON_CANONICAL_SYMLINKS);
     if (!read_all_with_crc(0, untrusted_namebuf, namelen))
         do_exit(LEGAL_EOF, NULL); // hopefully remote has produced error message
     untrusted_namebuf[namelen] = 0;

--- a/qrexec-lib/unpack.c
+++ b/qrexec-lib/unpack.c
@@ -346,7 +346,7 @@ static void process_one_file(struct file_header *untrusted_hdr, int flags)
     // Never set QUBES_PURE_ALLOW_NON_CANONICAL_PATHS -- paths from qfile-agent
     // will always be canonical.
     uint32_t validate_flags = ((uint32_t)flags >> 2) &
-        (QUBES_PURE_ALLOW_UNSAFE_CHARACTERS |
+        (QUBES_PURE_ALLOW_UNSAFE_CHARACTERS | QUBES_PURE_ALLOW_UNSAFE_SYMLINKS |
          QUBES_PURE_ALLOW_NON_CANONICAL_SYMLINKS);
     if (!read_all_with_crc(0, untrusted_namebuf, namelen))
         do_exit(LEGAL_EOF, NULL); // hopefully remote has produced error message

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -182,6 +182,14 @@ int main(int argc, char **argv)
         TEST("a/b", "b//c", QUBES_PURE_ALLOW_NON_CANONICAL_PATHS, true),
         // ...and non-canonical paths.
         TEST("a//b", "b//c", QUBES_PURE_ALLOW_NON_CANONICAL_PATHS, true),
+        // Symlinks may end in "/"...
+        TEST("a/b/c", "a/", QUBES_PURE_ALLOW_TRAILING_SLASH, true),
+        // ...even without QUBES_PURE_ALLOW_TRAILING_SLASH.
+        TEST("a/b/c", "a/", 0, true),
+        // but the path cannot...
+        TEST("a/b/c/", "a/", 0, false),
+        // ...unless QUBES_PURE_ALLOW_TRAILING_SLASH is passed.
+        TEST("a/b/c/", "a/", QUBES_PURE_ALLOW_TRAILING_SLASH, true),
     };
     int failed = 0;
 #define SYMLINK_TEST(a) symlink_test(a, sizeof(a)/sizeof(a[0]))

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -118,6 +118,8 @@ int main(int argc, char **argv)
     assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)".."));
     // Symlinks may end in "/".
     assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"a/"));
+    // Symlinks reject invalid paths.
+    assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"..", (const uint8_t *)"a/"));
 
     // Greek letters are safe
     assert(qubes_pure_validate_file_name((uint8_t *)u8"\u03b2.txt"));

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -219,4 +219,6 @@ int main(int argc, char **argv)
     assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"/a"));
     // Symlinks may end in "..".
     assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)".."));
+    // Symlinks may end in "/".
+    assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"a/"));
 }

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -172,6 +172,12 @@ int main(int argc, char **argv)
         TEST("a/b/c", "a/", 0, true),
         // Invalid paths are rejected...
         TEST("..", "a/", 0, false),
+        // ...even with QUBES_PURE_ALLOW_UNSAFE_SYMLINKS.
+        TEST("..", "a/", QUBES_PURE_ALLOW_UNSAFE_SYMLINKS, false),
+        // but QUBES_PURE_ALLOW_UNSAFE_SYMLINKS allows bad symlinks
+        TEST("a", "/home/user/.bashrc", QUBES_PURE_ALLOW_UNSAFE_SYMLINKS, true),
+        // that are otherwise rejected
+        TEST("a", "/home/user/.bashrc", 0, false),
         // QUBES_PURE_ALLOW_NON_CANONICAL_PATHS allows non-canonical symlinks...
         TEST("a/b", "b//c", QUBES_PURE_ALLOW_NON_CANONICAL_PATHS, true),
         // ...and non-canonical paths.

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -70,34 +70,34 @@ int main(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-    assert(qubes_pure_validate_file_name((uint8_t *)u8"simple_safe_filename.txt"));
+    assert(qubes_pure_validate_file_name((const uint8_t *)u8"simple_safe_filename.txt"));
 
     // Directory traversal checks
-    assert(!qubes_pure_validate_file_name((uint8_t *)".."));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"../.."));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"a/.."));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"a/../b"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"/"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"//"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"///"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"/a"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"//a"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"///a"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)".."));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"../.."));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"a/.."));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"a/../b"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"/"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"//"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"///"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"/a"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"//a"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"///a"));
 
     // No repeated slashes
-    assert(!qubes_pure_validate_file_name((uint8_t *)"a//b"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"a//b"));
 
     // No "." as a path component
-    assert(!qubes_pure_validate_file_name((uint8_t *)"."));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"a/."));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"./a"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"a/./a"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"."));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"a/."));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"./a"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"a/./a"));
 
     // No ".." as a path component
-    assert(!qubes_pure_validate_file_name((uint8_t *)".."));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"a/.."));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"../a"));
-    assert(!qubes_pure_validate_file_name((uint8_t *)"a/../a"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)".."));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"a/.."));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"../a"));
+    assert(!qubes_pure_validate_file_name((const uint8_t *)"a/../a"));
 
     // Looks like "." or ".." but is not
     assert(qubes_pure_validate_file_name((const uint8_t *)".a"));

--- a/qrexec-lib/validator-test.c
+++ b/qrexec-lib/validator-test.c
@@ -217,4 +217,6 @@ int main(int argc, char **argv)
     assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"../a"));
     // Absolute symlinks are rejected
     assert(!qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)"/a"));
+    // Symlinks may end in "..".
+    assert(qubes_pure_validate_symbolic_link((const uint8_t *)"a/b/c", (const uint8_t *)".."));
 }


### PR DESCRIPTION
This allows copying paths with names that would otherwise be forbidden.
This requires adding new APIs, so take the opportunity to provide more
useful information about why a path was rejected.

To ensure that internal invariants are not violated, this uses a new
COMPILETIME_UNREACHABLE macro to validate that a statement can be proven
unreachable by the compiler.  This is superior to abort() because it is
checked at compile-time by the optimizer: if the compiler cannot prove
that the code is unreachable, the build will fail.  This technique is
also used by BUILD_BUG_ON() in the Linux kernel.  Since compilers do not
promise to always be able to prove a piece of code unreachable, static
checking is disabled by default.  It can be enabled by including
CHECK_UNREACHABLE=1 in the build environment.

This is part of QubesOS/qubes-issues#8332 (less restricted qfile-copy),
but that issue also requires changes to qfile-unpacker (part of
qubes-core-agent-linux) to fix.  The code is both backwards and forwards
compatible: Old qfile-unpacker versions will work fine with the new
library, and new qfile-unpacker versions will work fine with the old
library.  However, qubes.UnsafeFileCopy will behave like qubes.Filecopy
unless the library has been updated.

Initially, I decided to unconditionally disallow ASCII control
characters in filenames, even if other character set filtering is
disabled.  This is because they are very useful for exploits and not
very useful for other purposes.  However, they can still arise in
practice for completely legitimate reasons.  These include copying and
pasting into a file name in a GUI file manager and deliberately creating
strangely-named files for test purposes.  Therefore, disabling filtering
now disables _all_ character set filtering.  Restrictions to prevent
directory traversal are still enforced, though, because violations of
these are much more likely to be exploitable.  While symlinks that point
outside of the directory being copied might arise legitimately, they
will not be meaningful after being copied and _do_ allow an attacker to
cause mischief.  For instance, if a symlink points to
/home/user/.bashrc, "cp a b" in a directory copied by qvm-copy could
overwrite ~/.bashrc with attacker-controlled data.  The checks on
symlink paths prevent this.
