### PR TITLE
Ensure that qubesdb SELinux labels are correct on Fedora 41

### DIFF
--- a/selinux/qubes-meminfo-writer.fc
+++ b/selinux/qubes-meminfo-writer.fc
@@ -1,2 +1,3 @@
+/usr/bin/meminfo-writer  -- gen_context(system_u:object_r:qubes_meminfo_writer_exec_t,s0)
 /usr/sbin/meminfo-writer -- gen_context(system_u:object_r:qubes_meminfo_writer_exec_t,s0)
 /run/meminfo-writer\.pid -- gen_context(system_u:object_r:qubes_meminfo_writer_var_run_t,s0)


### PR DESCRIPTION
/usr/sbin is now considered an alias for /usr/bin, so include rules for /usr/bin to ensure correct labelling.  Do not remove the old rules to avoid regression on Fedora 40.

Suggested-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
Part-of: QubesOS/qubes-issues#9663