### PR TITLE
rpm: adjust SELinux snippets for relabeling

### DIFF
--- a/rpm_spec/qubes-utils.spec.in
+++ b/rpm_spec/qubes-utils.spec.in
@@ -72,6 +72,9 @@ License: GPLv2+
 SELinux policy for meminfo-writer.  You need this package to run meminfo-writer
 on a system where SELinux is in enforcing mode.
 
+%pre selinux
+%selinux_relabel_pre
+
 %post selinux
 %selinux_modules_install %{_datadir}/selinux/packages/qubes-meminfo-writer.pp || :
 


### PR DESCRIPTION
Adjust according to https://fedoraproject.org/wiki/SELinux/IndependentPolicy#Creating_the_Spec_File

Specifically, when %selinux_relabel_post is used, %selinux_relabel_pre
needs to be there too.

QubesOS/qubes-issues#9663