### PR TITLE
Move meminfo-writer to /usr/bin

### DIFF
--- a/debian/qubes-utils.install
+++ b/debian/qubes-utils.install
@@ -1,4 +1,4 @@
-usr/sbin/meminfo-writer
+usr/bin/meminfo-writer
 lib/systemd/system/qubes-meminfo-writer.service
 usr/lib/qubes/*
 usr/lib/udev/*

--- a/qmemman/Makefile
+++ b/qmemman/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 CFLAGS+=-Wall -Wextra -Werror -g -O3
 all:	meminfo-writer
-SBINDIR?=/usr/sbin
+BINDIR?=/usr/bin
 
 _XENSTORE_H=$(shell ls /usr/include/xenstore.h)
 ifneq "$(_XENSTORE_H)" ""
@@ -11,7 +11,7 @@ endif
 meminfo-writer: meminfo-writer.o
 	$(CC) $(LDFLAGS) -g -o meminfo-writer meminfo-writer.o -lxenstore
 install:
-	install -D meminfo-writer $(DESTDIR)/$(SBINDIR)/meminfo-writer
+	install -D meminfo-writer $(DESTDIR)/$(BINDIR)/meminfo-writer
 ifeq (1,${DEBIANBUILD})
 	install -d $(DESTDIR)/lib/systemd/system/
 	install -m 0644 qubes-meminfo-writer.service $(DESTDIR)/lib/systemd/system/

--- a/qmemman/qubes-meminfo-writer-dom0.service
+++ b/qmemman/qubes-meminfo-writer-dom0.service
@@ -6,7 +6,7 @@ ConditionPathExists=/run/qubes/qmemman.sock
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/meminfo-writer 30000 100000
+ExecStart=/usr/bin/meminfo-writer 30000 100000
 RemainAfterExit=yes
 
 [Install]

--- a/qmemman/qubes-meminfo-writer.service
+++ b/qmemman/qubes-meminfo-writer.service
@@ -5,7 +5,7 @@ Before=systemd-user-sessions.service
 
 [Service]
 Type=forking
-ExecStart=/usr/sbin/meminfo-writer 30000 100000 /run/meminfo-writer.pid
+ExecStart=/usr/bin/meminfo-writer 30000 100000 /run/meminfo-writer.pid
 PIDFile=/run/meminfo-writer.pid
 
 [Install]

--- a/rpm_spec/qubes-utils.spec.in
+++ b/rpm_spec/qubes-utils.spec.in
@@ -132,7 +132,7 @@ rm -rf $RPM_BUILD_ROOT
 %_tmpfilesdir/xen-devices-qubes.conf
 %dir %{_prefix}/lib/qubes
 %{_prefix}/lib/qubes/udev-*
-%{_sbindir}/meminfo-writer
+%{_bindir}/meminfo-writer
 %{_unitdir}/qubes-meminfo-writer.service
 %{_unitdir}/qubes-meminfo-writer-dom0.service
 %dir %_includedir/qubes

--- a/selinux/qubes-meminfo-writer.fc
+++ b/selinux/qubes-meminfo-writer.fc
@@ -1,3 +1,2 @@
 /usr/bin/meminfo-writer  -- gen_context(system_u:object_r:qubes_meminfo_writer_exec_t,s0)
-/usr/sbin/meminfo-writer -- gen_context(system_u:object_r:qubes_meminfo_writer_exec_t,s0)
 /run/meminfo-writer\.pid -- gen_context(system_u:object_r:qubes_meminfo_writer_var_run_t,s0)


### PR DESCRIPTION
There it a tendency to merge /usr/bin and /usr/sbin (replace the latter
with a symlink). This caused a few issues already, including SELinux
mislabeling (QubesOS/qubes-issues#9663), file install issues where
%_sbindir RPM macro points at /usr/bin, and now on in-place upgrade
systemd unit points at /usr/sbin/meminfo-writer that doesn't exist at
the upgrade time.

Since this merging happened on Fedora 42 now, and much earlier on
Archlinux too, simplify things by simply moving meminfo-writer to
/usr/bin and don't have any special cases for distributions with merged
/usr/sbin or not. The change isn't relevant for Debian (yet?) but also
shouldn't hurt either.

QubesOS/qubes-issues#9807