### PR TITLE
Fix initramfs for archlinux in-vm kernel

### DIFF
--- a/archlinux/PKGBUILD-initcpio-install.sh
+++ b/archlinux/PKGBUILD-initcpio-install.sh
@@ -5,7 +5,9 @@ build() {
   add_module "xen-blkfront"
   add_binary "/usr/bin/sfdisk"
   add_binary "/usr/bin/mkswap"
+  add_binary "/usr/bin/swapon"
   add_binary "/usr/bin/dmsetup"
+  add_binary "/usr/bin/gptfix"
   add_binary "/usr/lib/qubes/qubes_cow_setup.sh"
   
   add_runscript

--- a/archlinux/PKGBUILD-qubes-vm-kernel-support.install
+++ b/archlinux/PKGBUILD-qubes-vm-kernel-support.install
@@ -22,7 +22,7 @@ $end"
   if [[ ! -s /etc/default/grub ]]; then
     echo >> /etc/default/grub
   fi
-  sed -Ei 's/^(HOOKS=[("])base/\1lvm2 qubes base/' /etc/mkinitcpio.conf
+  sed -Ei '/^HOOKS=/ s/(block)/\1 lvm2 qubes/' /etc/mkinitcpio.conf
   echo 'Adding qubes required hooks to /etc/default/grub'
   sed -Ei "/^$begin\$/,/^$end\$/{
 \$c$combined
@@ -41,7 +41,7 @@ post_upgrade () {
 post_remove () {
   local begin='### BEGIN QUBES HOOKS ###' end='### END QUBES HOOKS ###'
   echo 'Removing qubes required hooks from mkinitcpio.conf'
-  sed -Ei 's/^(HOOKS=[("])lvm2 qubes base/\1base/' /etc/mkinitcpio.conf
+  sed -Ei '/^HOOKS=/ s/(block) lvm2 qubes/\1/' /etc/mkinitcpio.conf
   echo 'Removing qubes required hooks from /etc/default/grub'
   sed -Ei "/^$begin\$/,/^$end\$/d" /etc/default/grub
   grub-mkconfig -o /boot/grub/grub.cfg


### PR DESCRIPTION
When booting an in-vm kernel with `qubes-vm-kernel-support` in Archlinux, the initramfs complains about missing `gptfix` binary (invoked in `qubes_cow_setup.sh`) and times out waiting for dmroot to be available. After adding `gptfix` it further complains about missing `swapon`. Adding those two binaries resolves the errors.