### PR TITLE
arch: fix SPDX license

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -6,7 +6,7 @@ pkgrel=@REL@
 pkgdesc="Common Linux files for Qubes VM."
 arch=("x86_64")
 url="http://qubes-os.org/"
-license=('GPL')
+license=('GPL-2.0-or-later')
 depends=(
     gcc
     make


### PR DESCRIPTION
The arch build logs errors regarding the `license` not being a recognized SPDX identifier. This changes it from `GPL` to `GPL-2.0-or-later`. Cleans up build logs.