### PR TITLE
fix(arch): create qubes group if missing on preinstall

### DIFF
--- a/archlinux/PKGBUILD-qubes-vm-utils.install
+++ b/archlinux/PKGBUILD-qubes-vm-utils.install
@@ -1,4 +1,9 @@
 
+pre_install () {
+  # Make sure there is a qubes group
+  groupadd --force --system --gid 98 qubes
+}
+
 ## arg 1:  the new package version
 post_install() {
   ldconfig


### PR DESCRIPTION
The packages implicitly depend on presence of the `qubes` group.

This ensures it is present as part of archlinux preinstall scripts.