### PR TITLE
Added exceptions to qubes udev device export

### DIFF
--- a/udev/udev-qubes-block.rules
+++ b/udev/udev-qubes-block.rules
@@ -12,6 +12,7 @@ ENV{MAJOR}=="202", GOTO="qubes_block_end"
 
 # skip devices excluded elsewhere
 ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}=="1", ENV{QUBES_EXPORT_BLOCK_DEVICE}!="1", GOTO="qubes_block_end"
+ENV{QUBES_EXPORT_BLOCK_DEVICE}=="0", GOTO="qubes_block_end"
 
 # Skip device-mapper devices
 KERNEL=="dm-*", ENV{DM_NAME}=="snapshot-*", GOTO="qubes_block_end"

--- a/udev/udev-qubes-usb.rules
+++ b/udev/udev-qubes-usb.rules
@@ -5,6 +5,7 @@ SUBSYSTEM!="usb", GOTO="qubes_usb_end"
 
 # ignore qemu emulated devices in HVM
 ENV{ID_VENDOR}=="QEMU", GOTO="qubes_usb_end"
+ENV{QUBES_EXPORT_USB_DEVICE}=="0", GOTO="qubes_usb_end"
 
 ACTION=="add", IMPORT{program}="/usr/lib/qubes/udev-usb-add-change"
 ACTION=="change", IMPORT{program}="/usr/lib/qubes/udev-usb-add-change"


### PR DESCRIPTION
After way too much troubleshooting I realized that the qubes udev rules break systemd device integration (specifically `.device` inode watching). This pull request enables exemptions to the qubes rules without also disabling other udev rules.

~~This enables [#977](/QubesOS/qubes-issues/issues/977), if you run the swap encryption in the VM.~~ (This is probably better achieved with `ephemeral` in `qvm-volume`, which I already had done and forgotten 🤦)

My use case is gone, but I still think that this should be merged, since it's a noninvasive change that enables udev rules that currently cannot be written (unless you surround the `99-qubes[...].rules` file and reset the env variable after it). 