### PR TITLE
Hide disks that other udev rules marked as hidden from udisks

### DIFF
--- a/udev/udev-qubes-block.rules
+++ b/udev/udev-qubes-block.rules
@@ -19,6 +19,9 @@ KERNEL=="dm-*", ENV{DM_NAME}=="snapshot-*", GOTO="qubes_block_end"
 KERNEL=="dm-*", ENV{DM_NAME}=="origin-*", GOTO="qubes_block_end"
 KERNEL=="dm-*", ENV{DM_NAME}=="", GOTO="qubes_block_end"
 
+# Skip zram devices
+KERNEL=="zram*", GOTO="qubes_block_end"
+
 ACTION=="add", RUN+="/usr/lib/qubes/udev-block-add-change"
 ACTION=="change", RUN+="/usr/lib/qubes/udev-block-add-change"
 ACTION=="remove", RUN+="/usr/lib/qubes/udev-block-remove"

--- a/udev/udev-qubes-block.rules
+++ b/udev/udev-qubes-block.rules
@@ -3,6 +3,9 @@
 # Only block devices are interesting
 SUBSYSTEM!="block", GOTO="qubes_block_end"
 
+# Skip devices hidden from udisks by other rules
+ENV{UDISKS_IGNORE}=="1", GOTO="qubes_block_end"
+
 # Hide qubes-internal drives from udisks, so file selection dialogs
 ENV{MAJOR}=="7", ENV{UDISKS_IGNORE}="1"
 KERNEL=="xvda|xvdb|xvdc*|xvdd", ENV{UDISKS_IGNORE}="1"


### PR DESCRIPTION
This specifically should hide system partitions like EFI or BIOS boot. But
do that before loop devices are hidden from udisks, as those are useful in
qvm-block (booting from ISO image etc).