### PR TITLE
Do not use full path to gptfix in dracut scripts

### DIFF
--- a/dracut/full-dmroot/qubes_cow_setup.sh
+++ b/dracut/full-dmroot/qubes_cow_setup.sh
@@ -56,7 +56,7 @@ log_begin "Waiting for /dev/xvda* devices..."
 udevadm settle --exit-if-exists=/dev/xvda
 
 # prefer partition if exists
-if /usr/sbin/gptfix fix /dev/xvda; then
+if gptfix fix /dev/xvda; then
     udevadm settle --exit-if-exists=/dev/xvda1
     if [ -e "/dev/disk/by-partlabel/Root\\x20filesystem" ]; then
         ROOT_DEV=$(readlink "/dev/disk/by-partlabel/Root\\x20filesystem")


### PR DESCRIPTION
Doing so is actively harmful and breaks booting on systems upgraded from prior to Fedora42 when updating to Qubes 4.3 due to the merging of /usr/sbin into /usr/bin logic

Expanded details in https://github.com/QubesOS/qubes-issues/issues/10547