### PR TITLE
tests: remove last-lba header from gptfixer/layout

### DIFF
--- a/gptfixer/layout
+++ b/gptfixer/layout
@@ -5,7 +5,6 @@ unit: sectors
 first-lba: 24
 sector-size: 512
 table-length: 33
-last-lba: 41943029
 
 /dev/loop0p1 : start=32, size=409592, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=FA4D6529-56DA-47C7-AE88-E2DFECB72621, name="EFI System"
 /dev/loop0p2 : start=411648, size=        4096, type=21686148-6449-6E6F-744E-656564454649, uuid=1E6C9DB4-1E91-46C4-846A-2030DCB13B8C, name="BIOS boot partition"

--- a/gptfixer/test.sh.stderr
+++ b/gptfixer/test.sh.stderr
@@ -5,7 +5,7 @@
 + chk 4096
 ++ sudo losetup --nooverlap --find --sector-size 4096 --show -- dummy.img
 + loopdev=/dev/loop0
-+ [[ /dev/loop0 != \/\d\e\v\/\l\o\o\p\0 ]]
++ [[ /dev/loop0 != /dev/loop0 ]]
 + echo Dumping broken partition table
 + sudo sfdisk --label=gpt --dump -- /dev/loop0
 GPT PMBR size mismatch (41943039 != 5242879) will be corrected by write.
@@ -17,7 +17,7 @@ gpt: Found GPT with different sector size, altering
 + chk 512
 ++ sudo losetup --nooverlap --find --sector-size 512 --show -- dummy.img
 + loopdev=/dev/loop0
-+ [[ /dev/loop0 != \/\d\e\v\/\l\o\o\p\0 ]]
++ [[ /dev/loop0 != /dev/loop0 ]]
 + echo Dumping broken partition table
 + sudo sfdisk --label=gpt --dump -- /dev/loop0
 GPT PMBR size mismatch (5242879 != 41943039) will be corrected by write.

--- a/gptfixer/test.sh.stdout
+++ b/gptfixer/test.sh.stdout
@@ -12,7 +12,6 @@ I/O size (minimum/optimal): 512 bytes / 512 bytes
 >>> Script header accepted.
 >>> Script header accepted.
 >>> Script header accepted.
->>> Script header accepted.
 >>> Created a new GPT disklabel (GUID: F4796A2A-E377-45BD-B539-D6D49E569055).
 The maximal number of partitions is 33 (default is 128).
 dummy.img1: Created a new partition 1 of type 'EFI System' and of size 200 MiB.


### PR DESCRIPTION
Newer sfdisk ignores it, with a warning, which makes the test fail.