### PR TITLE
Enable xen_privcmd.unrestricted for inter-vm communication to work

### DIFF
--- a/grub/grub.qubes-kernel-vm-support
+++ b/grub/grub.qubes-kernel-vm-support
@@ -5,6 +5,8 @@ if [ -r /usr/share/qubes/marker-vm ] &&
         [ "$(cat /var/lib/qubes/initramfs-updated 2>/dev/null || echo 0)" -ge 1 ]; then
     GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX xen_scrub_pages=0"
 fi
+# (currently) required for vchan
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX xen_privcmd.unrestricted"
 GRUB_ENABLE_BLSCFG=false
 # Add qubes version to boot menu on dom0
 if [ -f "/etc/qubes-release" ]; then


### PR DESCRIPTION
XSA-482 patch modified behavior of /dev/xen/privcmd, to disallow most
operations. This breaks vchan which uses xc_evtchn_status() (not
available via /dev/xen/evtchn yet).
Until proper abstraction via /dev/xen/evtchn is available, lift the
limitation via kernel parameter.
Note this does weaken in-VM isolation a bit (or rather: revert recent
improvement), especially against processes with access to
/dev/xen/privcmd. But it does not affect cross-VM isolation.