### PR TITLE
gptfixer/test.sh: make test loop-device agnostic

### DIFF
--- a/gptfixer/test.sh
+++ b/gptfixer/test.sh
@@ -3,11 +3,23 @@ set -euo pipefail
 
 case $0 in (/*) cd "${0%/*}/";; (*/*) cd "./${0%/*}";; (*) :;; esac
 make gpt
+
+ensure_loop_nodes () {
+    local n
+    for n in $(seq 0 15); do
+        [[ -e /dev/loop$n ]] && continue
+        if ! sudo mknod /dev/loop$n b 7 "$n" 2>/dev/null; then
+            echo "Cannot create /dev/loop$n; runner needs CAP_MKNOD or privileged" >&2
+            return 1
+        fi
+    done
+}
+
 chk () {
-    loopdev=$(sudo losetup --nooverlap --find --sector-size "$1" --show -- dummy.img)
-    if [[ "$loopdev" != '/dev/loop0' ]]; then
-        printf 'Loop device is not /dev/loop0 (got %q), expect test failure\n' "$loopdev"
-    fi >&3
+    if ! loopdev=$(sudo losetup --nooverlap --find --sector-size "$1" --show -- dummy.img); then
+        echo "losetup --find failed (kernel allocated a loop index whose /dev node is missing in this container)" >&2
+        return 1
+    fi
     echo Dumping broken partition table
     sudo sfdisk --label=gpt --dump -- "$loopdev"
     sudo ./gpt fix "$loopdev"
@@ -25,13 +37,25 @@ go () (
     chk 512
 )
 
+normalize_loop () {
+    sed -E 's|/dev/loop[0-9]+|/dev/loop0|g'
+}
+
 case "$#,${1-}" in
-('1,update') go 3>&2 > test.sh.stdout 2> test.sh.stderr;;
+('1,update')
+    ensure_loop_nodes
+    tmpdir=$(mktemp -d)
+    go 3>&2 > "$tmpdir/stdout" 2> "$tmpdir/stderr"
+    normalize_loop < "$tmpdir/stdout" > test.sh.stdout
+    normalize_loop < "$tmpdir/stderr" > test.sh.stderr
+    rm -rf -- "$tmpdir"
+;;
 (0,)
+    ensure_loop_nodes
     tmpdir=$(mktemp -d)
     go 3>&2 > "$tmpdir/stdout" 2> "$tmpdir/stderr" || { cat "$tmpdir/stderr"; exit 1; }
-    diff -u -- "$tmpdir/stdout" test.sh.stdout
-    diff -u -- "$tmpdir/stderr" test.sh.stderr
+    diff -u <(normalize_loop < "$tmpdir/stdout") test.sh.stdout
+    diff -u <(normalize_loop < "$tmpdir/stderr") test.sh.stderr
     rm -rf -- "$tmpdir"
 ;;
 (*) echo "Usage: test.sh [update]" >&2; exit 1;;

--- a/gptfixer/test.sh.stderr
+++ b/gptfixer/test.sh.stderr
@@ -5,7 +5,6 @@
 + chk 4096
 ++ sudo losetup --nooverlap --find --sector-size 4096 --show -- dummy.img
 + loopdev=/dev/loop0
-+ [[ /dev/loop0 != /dev/loop0 ]]
 + echo Dumping broken partition table
 + sudo sfdisk --label=gpt --dump -- /dev/loop0
 GPT PMBR size mismatch (41943039 != 5242879) will be corrected by write.
@@ -17,7 +16,6 @@ gpt: Found GPT with different sector size, altering
 + chk 512
 ++ sudo losetup --nooverlap --find --sector-size 512 --show -- dummy.img
 + loopdev=/dev/loop0
-+ [[ /dev/loop0 != /dev/loop0 ]]
 + echo Dumping broken partition table
 + sudo sfdisk --label=gpt --dump -- /dev/loop0
 GPT PMBR size mismatch (5242879 != 41943039) will be corrected by write.


### PR DESCRIPTION
Normalise /dev/loopN to /dev/loop0 in actual and expected output before diffing, mknod /dev/loop0..15 if missing (recovers from runners that don't pre-create loop nodes), and abort cleanly when losetup --find fails instead of continuing with an empty loopdev.

Drops the /dev/loop0 precondition warning, which is no longer relevant.