### PR TITLE
Calculate modules.img size dynamically

### DIFF
--- a/kernel-modules/qubes-prepare-vm-kernel
+++ b/kernel-modules/qubes-prepare-vm-kernel
@@ -44,10 +44,13 @@ function build_modules_img() {
         cp -a "/usr/src/kernels/$kver" "$tmpdir/modules/$kver/build"
     fi
 
+    size="$(du -sk "$tmpdir/modules")"
+    size="${size%%	*}"
+    size=$[ "$size" * 110 / 100 ]
     flags="-Enum_backup_sb=0,root_owner=0:0,no_copy_xattrs"
     flags="$flags,hash_seed=dcee2318-92bd-47a5-a15d-e79d1412cdce"
     PATH=/usr/sbin:/sbin:$PATH mkfs.ext3 -q -F "$flags" \
-        -d "$tmpdir/modules" "$tmpdir/modules.img" 768M
+        -d "$tmpdir/modules" "$tmpdir/modules.img" "$size"
     /usr/lib/qubes/vm-modules-genfs "$tmpdir/modules.img" "$kver" immutable=yes
     e2fsck -pDfE optimize_extents -- "$tmpdir/modules.img" >/dev/null
     resize2fs -fM -- "$tmpdir/modules.img" >/dev/null


### PR DESCRIPTION
Do not hardcode it at 768M, Linux 7.2 doesn't fit anymore.
